### PR TITLE
Release 0.3.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+Thank you for submitting a pull request! But first:
+
+ - [ ] Can you back your code up with tests?
+ - [ ] Keep your commits clean: [squash your commits if necessary](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History).
+ - [ ] Make sure you're targeting the `dev` branch with the PR.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.11-all.zip

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/ArgumentCaptor.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/ArgumentCaptor.kt
@@ -1,0 +1,31 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 Niek Haarman
+ * Copyright (c) 2007 Mockito contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.nhaarman.mockito_kotlin
+
+import org.mockito.ArgumentCaptor
+
+inline fun <reified T : Any> argumentCaptor() = ArgumentCaptor.forClass(T::class.java)
+inline fun <reified T : Any> capture(captor: ArgumentCaptor<T>): T = captor.capture() ?: createInstance<T>()

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/ArgumentCaptor.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/ArgumentCaptor.kt
@@ -29,3 +29,7 @@ import org.mockito.ArgumentCaptor
 
 inline fun <reified T : Any> argumentCaptor() = ArgumentCaptor.forClass(T::class.java)
 inline fun <reified T : Any> capture(captor: ArgumentCaptor<T>): T = captor.capture() ?: createInstance<T>()
+inline fun <reified T : Any> capture(noinline consumer: (T) -> Unit): T {
+    var times = 0
+    return argThat { if (++times == 1) consumer.invoke(this); true }
+}

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/CreateInstance.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/CreateInstance.kt
@@ -100,7 +100,7 @@ private fun <T : Any> KClass<T>.toArrayInstance(): T {
         "LongArray" -> longArrayOf()
         "DoubleArray" -> doubleArrayOf()
         "FloatArray" -> floatArrayOf()
-        else -> throw UnsupportedOperationException("Cannot create a generic array for $simpleName. Use createArrayInstance() instead.")
+        else -> throw UnsupportedOperationException("Cannot create a generic array for $simpleName. Use createArrayInstance() or anyArray() instead.")
     } as T
 }
 

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
@@ -25,47 +25,78 @@
 
 package com.nhaarman.mockito_kotlin
 
-import org.mockito.ArgumentCaptor
+import org.mockito.MockSettings
 import org.mockito.Mockito
+import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
-import org.mockito.stubbing.Stubber
 import org.mockito.verification.VerificationMode
 import kotlin.reflect.KClass
 
-inline fun <reified T : Any> mock() = Mockito.mock(T::class.java)
-inline fun <reified T : Any> mock(defaultAnswer: Answer<Any>) = Mockito.mock(T::class.java, defaultAnswer)
-fun <T : Any> spy(value: T) = Mockito.spy(value)
+fun after(millis: Long) = Mockito.after(millis)
 
-fun <T> whenever(methodCall: T) = Mockito.`when`(methodCall)
-fun <T> verify(mock: T) = Mockito.verify(mock)
-fun <T> verify(mock: T, mode: VerificationMode) = Mockito.verify(mock, mode)
-fun <T> verifyNoMoreInteractions(mock: T) = Mockito.verifyNoMoreInteractions(mock)
-fun <T> reset(mock: T) = Mockito.reset(mock)
+inline fun <reified T : Any> any() = Mockito.any(T::class.java) ?: createInstance<T>()
+inline fun <reified T : Any> anyArray(): Array<T> = Mockito.any(Array<T>::class.java) ?: arrayOf()
+inline fun <reified T : Any> anyCollection(): Collection<T> = Mockito.anyCollectionOf(T::class.java)
+inline fun <reified T : Any> anyList(): List<T> = Mockito.anyListOf(T::class.java)
+inline fun <reified T : Any> anySet(): Set<T> = Mockito.anySetOf(T::class.java)
+inline fun <reified K : Any, reified V : Any> anyMap(): Map<K, V> = Mockito.anyMapOf(K::class.java, V::class.java)
+inline fun <reified T : Any> anyVararg() = Mockito.anyVararg<T>() ?: createInstance<T>()
 
-fun inOrder(vararg value: Any) = Mockito.inOrder(*value)
-fun never() = Mockito.never()
-fun times(numInvocations: Int) = Mockito.times(numInvocations)
+inline fun <reified T : Any> argThat(noinline predicate: T.() -> Boolean) = Mockito.argThat<T> { it -> (it as T).predicate() } ?: createInstance(T::class)
+
 fun atLeast(numInvocations: Int) = Mockito.atLeast(numInvocations)
 fun atLeastOnce() = Mockito.atLeastOnce()
+fun atMost(maxNumberOfInvocations: Int) = Mockito.atMost(maxNumberOfInvocations)
+fun calls(wantedNumberOfInvocations: Int) = Mockito.calls(wantedNumberOfInvocations)
 
-fun doReturn(value: Any) = Mockito.doReturn(value)
-fun doThrow(throwable: Throwable) = Mockito.doThrow(throwable)
-fun <T> doAnswer(answer: Answer<T>) = Mockito.doAnswer(answer)
+fun <T> clearInvocations(vararg mocks: T) = Mockito.clearInvocations(*mocks)
+fun description(description: String) = Mockito.description(description)
+
+fun <T> doAnswer(answer: (InvocationOnMock) -> T?) = Mockito.doAnswer { answer(it) }
+
 fun doCallRealMethod() = Mockito.doCallRealMethod()
 fun doNothing() = Mockito.doNothing()
-
-fun <T> Stubber.whenever(mock: T) = `when`(mock)
-
-inline fun <reified T : Any> argumentCaptor() = ArgumentCaptor.forClass(T::class.java)
-inline fun <reified T : Any> capture(captor: ArgumentCaptor<T>): T = captor.capture() ?: createInstance<T>()
+fun doReturn(value: Any) = Mockito.doReturn(value)
+fun doReturn(toBeReturned: Any, vararg toBeReturnedNext: Any) = Mockito.doReturn(toBeReturned, *toBeReturnedNext)
+fun doThrow(toBeThrown: KClass<out Throwable>) = Mockito.doThrow(toBeThrown.java)
+fun doThrow(vararg toBeThrown: Throwable) = Mockito.doThrow(*toBeThrown)
 
 inline fun <reified T : Any> eq(value: T) = Mockito.eq(value) ?: createInstance<T>()
-inline fun <reified T : Any> anyArray(): Array<T> = Mockito.any(Array<T>::class.java) ?: arrayOf()
-inline fun <reified T : Any> any() = Mockito.any(T::class.java) ?: createInstance<T>()
+fun ignoreStubs(vararg mocks: Any) = Mockito.ignoreStubs(*mocks)
+fun inOrder(vararg mocks: Any) = Mockito.inOrder(*mocks)
+
+inline fun <reified T : Any> isA() = Mockito.isA(T::class.java)
+inline fun <reified T : Any> isNotNull() = Mockito.isNotNull(T::class.java)
 inline fun <reified T : Any> isNull(): T? = Mockito.isNull(T::class.java)
 
-inline fun <reified T : Any> argThat(noinline predicate: T.() -> Boolean) = argThat(T::class, predicate)
+inline fun <reified T : Any> mock() = Mockito.mock(T::class.java)
+inline fun <reified T : Any> mock(defaultAnswer: Answer<Any>) = Mockito.mock(T::class.java, defaultAnswer)
+inline fun <reified T : Any> mock(s: MockSettings) = Mockito.mock(T::class.java, s)
+inline fun <reified T : Any> mock(s: String) = Mockito.mock(T::class.java, s)
 
-@Suppress("UNCHECKED_CAST")
-fun <T : Any> argThat(kClass: KClass<T>, predicate: T.() -> Boolean)
-        = Mockito.argThat<T> { it -> (it as T).predicate() } ?: createInstance(kClass)
+fun mockingDetails(toInspect: Any) = Mockito.mockingDetails(toInspect)
+fun never() = Mockito.never()
+inline fun <reified T : Any> notNull() = Mockito.notNull(T::class.java)
+fun only() = Mockito.only()
+fun <T> refEq(value: T, vararg excludeFields: String) = Mockito.refEq(value, *excludeFields)
+
+fun reset() = Mockito.reset<Any>()
+fun <T> reset(vararg mocks: T) = Mockito.reset(*mocks)
+
+fun <T> same(value: T) = Mockito.same(value)
+
+inline fun <reified T : Any> spy() = Mockito.spy(T::class.java)
+fun <T> spy(value: T) = Mockito.spy(value)
+
+fun <T> stub(methodCall: T) = Mockito.stub(methodCall)
+fun timeout(millis: Long) = Mockito.timeout(millis)
+fun times(numInvocations: Int) = Mockito.times(numInvocations)
+fun validateMockitoUsage() = Mockito.validateMockitoUsage()
+
+fun <T> verify(mock: T) = Mockito.verify(mock)
+fun <T> verify(mock: T, mode: VerificationMode) = Mockito.verify(mock, mode)
+fun <T> verifyNoMoreInteractions(vararg mocks: T) = Mockito.verifyNoMoreInteractions(*mocks)
+fun verifyZeroInteractions(vararg mocks: Any) = Mockito.verifyZeroInteractions(*mocks)
+
+fun <T> whenever(methodCall: T) = Mockito.`when`(methodCall)
+fun withSettings() = Mockito.withSettings()

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
@@ -25,11 +25,15 @@
 
 package com.nhaarman.mockito_kotlin
 
+import org.mockito.ArgumentCaptor
 import org.mockito.Mockito
+import org.mockito.stubbing.Answer
+import org.mockito.stubbing.Stubber
 import org.mockito.verification.VerificationMode
 import kotlin.reflect.KClass
 
 inline fun <reified T : Any> mock() = Mockito.mock(T::class.java)
+inline fun <reified T : Any> mock(defaultAnswer: Answer<Any>) = Mockito.mock(T::class.java, defaultAnswer)
 fun <T : Any> spy(value: T) = Mockito.spy(value)
 
 fun <T> whenever(methodCall: T) = Mockito.`when`(methodCall)
@@ -40,6 +44,20 @@ fun <T> reset(mock: T) = Mockito.reset(mock)
 
 fun inOrder(vararg value: Any) = Mockito.inOrder(*value)
 fun never() = Mockito.never()
+fun times(numInvocations: Int) = Mockito.times(numInvocations)
+fun atLeast(numInvocations: Int) = Mockito.atLeast(numInvocations)
+fun atLeastOnce() = Mockito.atLeastOnce()
+
+fun doReturn(value: Any) = Mockito.doReturn(value)
+fun doThrow(throwable: Throwable) = Mockito.doThrow(throwable)
+fun <T> doAnswer(answer: Answer<T>) = Mockito.doAnswer(answer)
+fun doCallRealMethod() = Mockito.doCallRealMethod()
+fun doNothing() = Mockito.doNothing()
+
+fun <T> Stubber.whenever(mock: T) = `when`(mock)
+
+inline fun <reified T : Any> argumentCaptor() = ArgumentCaptor.forClass(T::class.java)
+inline fun <reified T : Any> capture(captor: ArgumentCaptor<T>): T = captor.capture() ?: createInstance<T>()
 
 inline fun <reified T : Any> eq(value: T) = Mockito.eq(value) ?: createInstance<T>()
 inline fun <reified T : Any> anyArray(): Array<T> = Mockito.any(Array<T>::class.java) ?: arrayOf()

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Stubber.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Stubber.kt
@@ -23,32 +23,8 @@
  * THE SOFTWARE.
  */
 
-import com.nhaarman.mockito_kotlin.argThat
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.verify
-import org.junit.Test
+package com.nhaarman.mockito_kotlin
 
-class MatcherTest {
+import org.mockito.stubbing.Stubber
 
-    @Test
-    fun argThat() {
-        /* Given */
-        val testClass: TestClass = mock()
-
-        /* When */
-        testClass.go(listOf("test"))
-
-        /* Then */
-        verify(testClass).go(
-                argThat {
-                    size == 1
-                    get(0) == "test"
-                }
-        )
-    }
-
-    interface TestClass {
-
-        fun go(v: List<String>)
-    }
-}
+fun <T> Stubber.whenever(mock: T) = `when`(mock)

--- a/mockito-kotlin/src/test/kotlin/ArgumentCaptorTest.kt
+++ b/mockito-kotlin/src/test/kotlin/ArgumentCaptorTest.kt
@@ -9,7 +9,7 @@ import java.util.*
 class ArgumentCaptorTest {
 
     @Test
-    fun captor() {
+    fun explicitCaptor() {
         val date: Date = mock()
         val time = argumentCaptor<Long>()
 
@@ -17,5 +17,15 @@ class ArgumentCaptorTest {
 
         verify(date).time = capture(time)
         expect(time.value).toBe(5L)
+    }
+
+    @Test
+    fun implicitCaptor() {
+        val date: Date = mock()
+        date.time = 5L
+
+        verify(date).time = capture {
+            expect(it).toBe(5L)
+        }
     }
 }

--- a/mockito-kotlin/src/test/kotlin/ArgumentCaptorTest.kt
+++ b/mockito-kotlin/src/test/kotlin/ArgumentCaptorTest.kt
@@ -7,6 +7,7 @@ import org.junit.Test
 import java.util.*
 
 class ArgumentCaptorTest {
+
     @Test
     fun captor() {
         val date: Date = mock()

--- a/mockito-kotlin/src/test/kotlin/ArgumentCaptorTest.kt
+++ b/mockito-kotlin/src/test/kotlin/ArgumentCaptorTest.kt
@@ -1,0 +1,20 @@
+import com.nhaarman.mockito_kotlin.argumentCaptor
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.expect.expect
+import com.nhaarman.mockito_kotlin.capture
+import org.junit.Test
+import java.util.*
+
+class ArgumentCaptorTest {
+    @Test
+    fun captor() {
+        val date: Date = mock()
+        val time = argumentCaptor<Long>()
+
+        date.time = 5L
+
+        verify(date).time = capture(time)
+        expect(time.value).toBe(5L)
+    }
+}

--- a/mockito-kotlin/src/test/kotlin/Classes.kt
+++ b/mockito-kotlin/src/test/kotlin/Classes.kt
@@ -23,7 +23,32 @@
 * THE SOFTWARE.
 */
 
-open class Fake {
-    open fun go(arg: Any?) {
+open class Open {
+    open fun go(vararg arg: Any?) {
     }
+
+    open fun modifiesContents(a: IntArray) {
+        for (i in 0..a.size - 1) {
+            a[i] = a[i] + 1
+        }
+    }
+
+    open fun stringResult() = "Default"
+}
+
+class Closed
+
+interface Methods {
+
+    fun intArray(i: IntArray)
+    fun closed(c: Closed)
+    fun closedArray(a: Array<Closed>)
+    fun closedCollection(c: Collection<Closed>)
+    fun closedList(c: List<Closed>)
+    fun closedStringMap(m: Map<Closed, String>)
+    fun closedSet(s: Set<Closed>)
+    fun string(s: String)
+    fun closedVararg(vararg c: Closed)
+
+    fun stringResult(): String
 }

--- a/mockito-kotlin/src/test/kotlin/CreateInstanceTest.kt
+++ b/mockito-kotlin/src/test/kotlin/CreateInstanceTest.kt
@@ -158,7 +158,7 @@ class CreateInstanceTest {
     @Test(expected = UnsupportedOperationException::class)
     fun classArray_usingAny() {
         /* When */
-        createInstance<Array<Fake>>()
+        createInstance<Array<Open>>()
     }
 
     @Test
@@ -371,7 +371,7 @@ class CreateInstanceTest {
     private class PrivateClass private constructor(val data: String)
 
     class ClosedClass
-    class ClosedParameterizedClass(val fake: Fake)
+    class ClosedParameterizedClass(val open: Open)
     class ClosedClosedParameterizedClass(val closed: ClosedParameterizedClass)
 
     class SingleParameterClass(val first: Byte)

--- a/mockito-kotlin/src/test/kotlin/EqTest.kt
+++ b/mockito-kotlin/src/test/kotlin/EqTest.kt
@@ -37,7 +37,7 @@ class EqTest {
     private val openClassInstance: MyClass = MyClass()
     private val closedClassInstance: ClosedClass = ClosedClass()
 
-    private lateinit var doAnswer: Fake
+    private lateinit var doAnswer: Open
 
     @Before
     fun setup() {

--- a/mockito-kotlin/src/test/kotlin/MockTest.kt
+++ b/mockito-kotlin/src/test/kotlin/MockTest.kt
@@ -25,8 +25,11 @@
 
 import com.nhaarman.expect.expect
 import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.whenever
 import org.junit.Test
+import org.mockito.Mockito.RETURNS_DEEP_STUBS
 import org.mockito.exceptions.base.MockitoException
+import java.util.*
 
 class MockTest {
 
@@ -80,6 +83,13 @@ class MockTest {
     @Test(expected = MockitoException::class)
     fun closedClass() {
         mock<ClosedClass>()
+    }
+
+    @Test
+    fun deepStubs() {
+        val cal: Calendar = mock(RETURNS_DEEP_STUBS)
+        whenever(cal.time.time).thenReturn(123L)
+        expect(cal.time.time).toBe(123L)
     }
 
     private interface MyInterface

--- a/mockito-kotlin/src/test/kotlin/MockitoTest.kt
+++ b/mockito-kotlin/src/test/kotlin/MockitoTest.kt
@@ -1,0 +1,257 @@
+import com.nhaarman.expect.expect
+import com.nhaarman.expect.expectErrorWithMessage
+import com.nhaarman.mockito_kotlin.*
+import org.junit.Test
+import org.mockito.exceptions.base.MockitoAssertionError
+
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 Niek Haarman
+ * Copyright (c) 2007 Mockito contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+class MockitoTest {
+
+    @Test
+    fun anyString() {
+        mock<Methods>().apply {
+            string("")
+            verify(this).string(any())
+        }
+    }
+
+    @Test
+    fun anyClosedClass() {
+        mock<Methods>().apply {
+            closed(Closed())
+            verify(this).closed(any())
+        }
+    }
+
+    @Test
+    fun anyIntArray() {
+        mock<Methods>().apply {
+            intArray(intArrayOf())
+            verify(this).intArray(any())
+        }
+    }
+
+    @Test
+    fun anyClassArray() {
+        mock<Methods>().apply {
+            closedArray(arrayOf(Closed()))
+            verify(this).closedArray(anyArray())
+        }
+    }
+
+    @Test
+    fun anyCollectionOfClosed() {
+        mock<Methods>().apply {
+            closedCollection(listOf())
+            verify(this).closedCollection(any())
+            verify(this).closedCollection(anyCollection())
+        }
+    }
+
+    @Test
+    fun anyListOfClosed() {
+        mock<Methods>().apply {
+            closedList(listOf())
+            verify(this).closedList(any())
+            verify(this).closedList(anyList())
+        }
+    }
+
+    @Test
+    fun anyClosedStringMap() {
+        mock<Methods>().apply {
+            closedStringMap(mapOf())
+            verify(this).closedStringMap(any())
+            verify(this).closedStringMap(anyMap())
+        }
+    }
+
+    @Test
+    fun anyClosedSet() {
+        mock<Methods>().apply {
+            closedSet(setOf())
+            verify(this).closedSet(any())
+            verify(this).closedSet(anySet())
+        }
+    }
+
+    @Test
+    fun anyStringVararg() {
+        mock<Methods>().apply {
+            closedVararg(Closed(), Closed())
+            verify(this).closedVararg(anyVararg())
+        }
+    }
+
+    @Test
+    fun listArgThat() {
+        mock<Methods>().apply {
+            closedList(listOf(Closed(), Closed()))
+            verify(this).closedList(argThat {
+                size == 2
+            })
+        }
+    }
+
+    @Test
+    fun atLeastXInvocations() {
+        mock<Methods>().apply {
+            string("")
+            string("")
+
+            verify(this, atLeast(2)).string(any())
+        }
+    }
+
+    @Test
+    fun testAtLeastOnce() {
+        mock<Methods>().apply {
+            string("")
+            string("")
+
+            verify(this, atLeastOnce()).string(any())
+        }
+    }
+
+    @Test
+    fun atMostXInvocations() {
+        mock<Methods>().apply {
+            string("")
+            string("")
+
+            verify(this, atMost(2)).string(any())
+        }
+    }
+
+    @Test
+    fun testCalls() {
+        mock<Methods>().apply {
+            string("")
+            string("")
+
+            inOrder(this).verify(this, calls(2)).string(any())
+        }
+    }
+
+    @Test
+    fun testClearInvocations() {
+        val mock = mock<Methods>().apply {
+            string("")
+        }
+
+        clearInvocations(mock)
+
+        verify(mock, never()).string(any())
+    }
+
+    @Test
+    fun testDescription() {
+        try {
+            mock<Methods>().apply {
+                verify(this, description("Test")).string(any())
+            }
+            throw AssertionError("Verify should throw Exception.")
+        } catch (e: MockitoAssertionError) {
+            expect(e.message).toContain("Test")
+        }
+    }
+
+    @Test
+    fun testDoAnswer() {
+        val mock = mock<Methods>()
+
+        doAnswer { "Test" }
+                .whenever(mock)
+                .stringResult()
+
+        expect(mock.stringResult()).toBe("Test")
+    }
+
+    @Test
+    fun testDoCallRealMethod() {
+        val mock = mock<Open>()
+
+        doReturn("Test").whenever(mock).stringResult()
+        doCallRealMethod().whenever(mock).stringResult()
+
+        expect(mock.stringResult()).toBe("Default")
+    }
+
+    @Test
+    fun testDoNothing() {
+        val spy = spy(Open())
+        val array = intArrayOf(3)
+
+        doNothing().whenever(spy).modifiesContents(array)
+        spy.modifiesContents(array)
+
+        expect(array[0]).toBe(3)
+    }
+
+    @Test
+    fun testDoReturnValue() {
+        val mock = mock<Methods>()
+
+        doReturn("test").whenever(mock).stringResult()
+
+        expect(mock.stringResult()).toBe("test")
+    }
+
+    @Test
+    fun testDoReturnValues() {
+        val mock = mock<Methods>()
+
+        doReturn("test", "test2").whenever(mock).stringResult()
+
+        expect(mock.stringResult()).toBe("test")
+        expect(mock.stringResult()).toBe("test2")
+    }
+
+    @Test
+    fun testDoThrowClass() {
+        val mock = mock<Open>()
+
+        doThrow(IllegalStateException::class).whenever(mock).go()
+
+        try {
+            mock.go()
+            throw AssertionError("Call should have thrown.")
+        } catch(e: IllegalStateException) {
+        }
+    }
+
+    @Test
+    fun testDoThrow() {
+        val mock = mock<Open>()
+
+        doThrow(IllegalStateException("test")).whenever(mock).go()
+
+        expectErrorWithMessage("test").on {
+            mock.go()
+        }
+    }
+}

--- a/mockito-kotlin/src/test/kotlin/SpyTest.kt
+++ b/mockito-kotlin/src/test/kotlin/SpyTest.kt
@@ -24,11 +24,12 @@
  */
 
 import com.nhaarman.expect.expect
-import com.nhaarman.mockito_kotlin.spy
+import com.nhaarman.mockito_kotlin.*
 import org.junit.After
 import org.junit.Test
 import org.mockito.Mockito
 import org.mockito.exceptions.base.MockitoException
+import java.util.*
 
 class SpyTest {
 
@@ -64,6 +65,36 @@ class SpyTest {
     fun spyClosedClassInstance() {
         /* When */
         spy(closedClassInstance)
+    }
+
+    @Test
+    fun doReturnWithSpy() {
+        val date = spy(Date())
+        doReturn(123L).whenever(date).time
+        expect(date.time).toBe(123L)
+    }
+
+    @Test
+    fun doNothingWithSpy() {
+        val date = spy(Date(0))
+        doNothing().whenever(date).time = 5L
+        date.time = 5L;
+        expect(date.time).toBe(0L)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun doThrowWithSpy() {
+        val date = spy(Date(0))
+        doThrow(IllegalArgumentException()).whenever(date).time
+        date.time
+    }
+
+    @Test
+    fun doCallRealMethodWithSpy() {
+        val date = spy(Date(0))
+        doReturn(123L).whenever(date).time
+        doCallRealMethod().whenever(date).time
+        expect(date.time).toBe(0L)
     }
 
     private interface MyInterface


### PR DESCRIPTION
 - Includes more static Mockito methods
 - `capture` can now be used with a lambda (thanks @cbxp):

```kotlin
val date: Date = mock()
date.time = 5L

verify(date).time = capture {
    expect(it).toBe(5L)
}
```