### PR TITLE
Avoid constructors with an array as a parameter.

### DIFF
--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/CreateInstance.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/CreateInstance.kt
@@ -54,8 +54,28 @@ fun <T : Any> createInstance(kClass: KClass<T>): T {
         kClass.isPrimitive() -> kClass.toDefaultPrimitiveValue()
         kClass.isEnum() -> kClass.java.enumConstants.first()
         kClass.isArray() -> kClass.toArrayInstance()
-        else -> kClass.constructors.sortedBy { it.parameters.size }.first().newInstance()
+        else -> kClass.easiestConstructor().newInstance()
     }
+}
+
+/**
+ * Tries to find the easiest constructor which it can instantiate.
+ */
+private fun <T : Any> KClass<T>.easiestConstructor(): KFunction<T> {
+    return constructors.firstOrDefault(
+            {
+                it.parameters.filter {
+                    it.type.toString().toLowerCase().contains("array")
+                }.isEmpty()
+            },
+            {
+                constructors.sortedBy { it.parameters.size }.first()
+            }
+    )
+}
+
+private fun <T> Collection<T>.firstOrDefault(predicate: (T) -> Boolean, default: () -> T): T {
+    return firstOrNull(predicate) ?: default()
 }
 
 @Suppress("SENSELESS_COMPARISON")

--- a/mockito-kotlin/src/test/kotlin/CreateInstanceTest.kt
+++ b/mockito-kotlin/src/test/kotlin/CreateInstanceTest.kt
@@ -26,6 +26,7 @@
 import com.nhaarman.expect.expect
 import com.nhaarman.mockito_kotlin.createInstance
 import org.junit.Test
+import java.util.*
 
 class CreateInstanceTest {
 
@@ -366,6 +367,21 @@ class CreateInstanceTest {
 
         /* Then */
         expect(result).toNotBeNull()
+    }
+
+    @Test
+    fun uuid() {
+        /**
+         * The UUID class has a single-argument constructor that expects an array with some specific contents.
+         * We avoid these types of constructors by calling another constructor, if available.
+         * In this case, UUID(Long, Long).
+         */
+
+        /* When */
+        val result = createInstance<UUID>()
+
+        /* Then */
+        expect(result).toBeEqualTo(UUID(0, 0))
     }
 
     private class PrivateClass private constructor(val data: String)


### PR DESCRIPTION
The UUID class has a single-argument constructor which
expects an array with some specific contents.
This commit tries to avoid these type of constructors,
since it may be a common case.
Instead, it tries to find a constructor without an array
parameter, or otherwise falls back.