### PR TITLE
Introduce instance creators.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,20 @@ For generic arrays, use the `anyArray()` method:
 verify(myClass).setItems(anyArray())
 ```
 
+## Custom instance creators
+
+There are some cases where Mockito-Kotlin cannot create an instance of a class. 
+This can for instance be when a constructor has some specific preconditions
+for its parameters.
+You can _register_ `instance creators` to overcome this:
+
+```kotlin
+MockitoKotlin.registerInstanceCreator<MyClass> { MyClass(5) }
+```
+
+Whenever MockitoKotlin needs to create an instance of `MyClass`, this function is called,
+giving you ultimate control over how these instances are created.
+
 ### Argument Matchers
 
 Using higher-order functions, you can write very clear expectations about expected values.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ MockitoKotlin.registerInstanceCreator<MyClass> { MyClass(5) }
 Whenever MockitoKotlin needs to create an instance of `MyClass`, this function is called,
 giving you ultimate control over how these instances are created.
 
+These instance creators work on a per-file basis: for each of your test files
+you will need to register them again.
+
 ### Argument Matchers
 
 Using higher-order functions, you can write very clear expectations about expected values.

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/MockitoKotlin.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/MockitoKotlin.kt
@@ -1,0 +1,69 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 Niek Haarman
+ * Copyright (c) 2007 Mockito contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.nhaarman.mockito_kotlin
+
+import java.util.*
+import kotlin.reflect.KClass
+
+class MockitoKotlin {
+
+    companion object {
+
+        /**
+         * Maps KClasses to functions that can create an instance of that KClass.
+         */
+        private val creators: MutableMap<KClass<*>, () -> Any> = HashMap()
+
+        /**
+         * Registers a function to be called when an instance of T is necessary.
+         */
+        inline fun <reified T : Any> registerInstanceCreator(noinline creator: () -> T) = registerInstanceCreator(T::class, creator)
+
+        /**
+         * Registers a function to be called when an instance of T is necessary.
+         */
+        fun <T : Any> registerInstanceCreator(kClass: KClass<T>, creator: () -> T) = creators.put(kClass, creator)
+
+        /**
+         * Unregisters an instance creator.
+         */
+        inline fun <reified T : Any> unregisterInstanceCreator() = unregisterInstanceCreator(T::class)
+
+        /**
+         * Unregisters an instance creator.
+         */
+        fun <T : Any> unregisterInstanceCreator(kClass: KClass<T>) = creators.remove(kClass)
+
+        /**
+         * Clears al instance creators.
+         */
+        fun resetInstanceCreators() = creators.clear()
+
+        internal fun <T : Any> instanceCreator(kClass: KClass<T>): (() -> Any)? {
+            return creators[kClass]
+        }
+    }
+}

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/MockitoKotlinException.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/MockitoKotlinException.kt
@@ -1,0 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 Niek Haarman
+ * Copyright (c) 2007 Mockito contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.nhaarman.mockito_kotlin
+
+class MockitoKotlinException(message: String?, cause: Throwable?) : RuntimeException(message, cause)

--- a/mockito-kotlin/src/test/kotlin/CreateInstanceTest.kt
+++ b/mockito-kotlin/src/test/kotlin/CreateInstanceTest.kt
@@ -24,6 +24,8 @@
  */
 
 import com.nhaarman.expect.expect
+import com.nhaarman.expect.expectErrorWithMessage
+import com.nhaarman.mockito_kotlin.MockitoKotlin
 import com.nhaarman.mockito_kotlin.createInstance
 import org.junit.Test
 import java.util.*
@@ -403,6 +405,25 @@ class CreateInstanceTest {
         expect(result).toBe(UUID(0, 0))
     }
 
+    @Test
+    fun registeredInstanceCreator() {
+        /* Given */
+        MockitoKotlin.registerInstanceCreator { ForbiddenConstructor(2) }
+
+        /* When */
+        val result = createInstance<ForbiddenConstructor>()
+
+        /* Then */
+        expect(result).toNotBeNull()
+    }
+
+    @Test
+    fun failedConstructor_throwsDescriptiveError() {
+        expectErrorWithMessage("Could not create an instance of class") on {
+            createInstance<ForbiddenConstructor>()
+        }
+    }
+
     private class PrivateClass private constructor(val data: String)
 
     class ClosedClass
@@ -427,6 +448,16 @@ class CreateInstanceTest {
 
     class ParameterizedClass<T>(val t: T)
     class NullableParameterClass(val s: String?)
+
+    class ForbiddenConstructor {
+
+        constructor() {
+            throw AssertionError("Forbidden.")
+        }
+
+        constructor(value: Int) {
+        }
+    }
 
     enum class MyEnum { VALUE, ANOTHER_VALUE }
 }

--- a/mockito-kotlin/src/test/kotlin/MockitoKotlinTest.kt
+++ b/mockito-kotlin/src/test/kotlin/MockitoKotlinTest.kt
@@ -1,0 +1,59 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 Niek Haarman
+ * Copyright (c) 2007 Mockito contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import com.nhaarman.expect.expect
+import com.nhaarman.mockito_kotlin.MockitoKotlin
+import com.nhaarman.mockito_kotlin.createInstance
+import org.junit.Test
+
+class MockitoKotlinTest {
+
+    @Test
+    fun register() {
+        /* Given */
+        val closed = Closed()
+        MockitoKotlin.registerInstanceCreator { closed }
+
+        /* When */
+        val result = createInstance<Closed>()
+
+        /* Then */
+        expect(result).toBe(closed)
+    }
+
+    @Test
+    fun unregister() {
+        /* Given */
+        val closed = Closed()
+        MockitoKotlin.registerInstanceCreator { closed }
+        MockitoKotlin.unregisterInstanceCreator<Closed>()
+
+        /* When */
+        val result = createInstance<Closed>()
+
+        /* Then */
+        expect(result).toNotBeReferentially(closed)
+    }
+}


### PR DESCRIPTION
These are functions `() -> T` that are invoked when
an instance of `T` is needed, instead of manually
trying to figure out which constructor to use.

Fixes #20.