### PR TITLE
Unset the MockitoInterceptor for unchecked mocks.

### DIFF
--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/CreateInstance.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/CreateInstance.kt
@@ -27,6 +27,7 @@ package com.nhaarman.mockito_kotlin
 
 import org.mockito.Answers
 import org.mockito.internal.creation.MockSettingsImpl
+import org.mockito.internal.creation.bytebuddy.MockMethodInterceptor
 import org.mockito.internal.util.MockUtil
 import java.lang.reflect.Modifier
 import java.lang.reflect.ParameterizedType
@@ -160,5 +161,7 @@ private fun <T : Any> KType.createNullableInstance(): T? {
 private fun <T> Class<T>.uncheckedMock(): T {
     val impl = MockSettingsImpl<T>().defaultAnswer(Answers.RETURNS_DEFAULTS) as MockSettingsImpl<T>
     val creationSettings = impl.confirm(this)
-    return MockUtil().createMock(creationSettings)
+    return MockUtil().createMock(creationSettings).apply {
+        (this as MockMethodInterceptor.MockAccess).mockitoInterceptor = null
+    }
 }

--- a/mockito-kotlin/src/test/kotlin/Classes.kt
+++ b/mockito-kotlin/src/test/kotlin/Classes.kt
@@ -49,6 +49,9 @@ interface Methods {
     fun closedSet(s: Set<Closed>)
     fun string(s: String)
     fun closedVararg(vararg c: Closed)
+    fun throwableClass(t: ThrowableClass)
 
     fun stringResult(): String
 }
+
+class ThrowableClass(cause: Throwable) : Throwable(cause)

--- a/mockito-kotlin/src/test/kotlin/MockitoTest.kt
+++ b/mockito-kotlin/src/test/kotlin/MockitoTest.kt
@@ -3,6 +3,7 @@ import com.nhaarman.expect.expectErrorWithMessage
 import com.nhaarman.mockito_kotlin.*
 import org.junit.Test
 import org.mockito.exceptions.base.MockitoAssertionError
+import java.io.IOException
 
 /*
  * The MIT License
@@ -104,6 +105,14 @@ class MockitoTest {
         mock<Methods>().apply {
             closedVararg(Closed(), Closed())
             verify(this).closedVararg(anyVararg())
+        }
+    }
+
+    @Test
+    fun anyThrowableWithSingleThrowableConstructor() {
+        mock<Methods>().apply {
+            throwableClass(ThrowableClass(IOException()))
+            verify(this).throwableClass(any())
         }
     }
 


### PR DESCRIPTION
This allows the default functions to be called on these mocks during verification.
Apparently, the MockitoInterceptor added by Mockito does some internal state checking.
This is not necessary here.

Fixes #27.