### PR TITLE
Updated kotlin and JUnit dependencies. Changed the JUnit because 1.10…

### DIFF
--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'kotlin'
 
 buildscript {
-  ext.kotlin_version = '1.0.0'
+  ext.kotlin_version = '1.0.1-2'
 
   repositories {
     mavenCentral()
@@ -20,7 +20,7 @@ repositories {
 dependencies {
   compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-  compile "org.mockito:mockito-core:2.0.39-beta"
+  compile "org.mockito:mockito-core:1.10.19"
 
   /* Tests */
   testCompile "junit:junit:4.12"


### PR DESCRIPTION
- [ ] Can you back your code up with tests?
 - [x] Keep your commits clean: [squash your commits if necessary](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History).
 - [x] Make sure you're targeting the `dev` branch with the PR.

I had this problem, compiling my project: 
```
Error:Conflict with dependency 'org.jetbrains.kotlin:kotlin-stdlib'. Resolved versions for app (1.0.1-2) and test app (1.0.0) differ. See http://g.co/androidstudio/app-test-app-conflict for details.
Error:Conflict with dependency 'org.jetbrains.kotlin:kotlin-runtime'. Resolved versions for app (1.0.1-2) and test app (1.0.0) differ. See http://g.co/androidstudio/app-test-app-conflict for details.
```
Solved using the last kotlin dependency. Updated mockito dependency as well.