### PR TITLE
Fixed ClassCastException thrown when using with PowerMock

### DIFF
--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -22,9 +22,15 @@ dependencies {
   compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
   compile "org.mockito:mockito-core:2.0.52-beta"
 
+
   /* Tests */
   testCompile "junit:junit:4.12"
   testCompile "com.nhaarman:expect.kt:0.5.1"
+  testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
+
+  def powermockVersion = "1.6.5"
+  testCompile "org.powermock:powermock-module-junit4:${powermockVersion}"
+  testCompile "org.powermock:powermock-api-mockito2:${powermockVersion}"
 }
 
 publishing {

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/CreateInstance.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/CreateInstance.kt
@@ -162,6 +162,8 @@ private fun <T> Class<T>.uncheckedMock(): T {
     val impl = MockSettingsImpl<T>().defaultAnswer(Answers.RETURNS_DEFAULTS) as MockSettingsImpl<T>
     val creationSettings = impl.confirm(this)
     return MockUtil().createMock(creationSettings).apply {
-        (this as MockMethodInterceptor.MockAccess).mockitoInterceptor = null
+      when (this) {
+        is MockMethodInterceptor.MockAccess -> mockitoInterceptor = null
+      }
     }
 }

--- a/mockito-kotlin/src/test/kotlin/CreateInstancePowermockTest.kt
+++ b/mockito-kotlin/src/test/kotlin/CreateInstancePowermockTest.kt
@@ -1,0 +1,58 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 Niek Haarman
+ * Copyright (c) 2007 Mockito contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import com.nhaarman.expect.expect
+import com.nhaarman.mockito_kotlin.createInstance
+import com.nhaarman.mockito_kotlin.doReturn
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.powermock.core.classloader.annotations.PrepareForTest
+import org.powermock.modules.junit4.PowerMockRunner
+import kotlin.test.expect
+
+@RunWith(PowerMockRunner::class)
+@PrepareForTest(
+    CreateInstancePowermockTest.ActualImplementationClass::class
+)
+class CreateInstancePowermockTest {
+
+  @Test
+  fun nullableParameterClass() {
+    /* When */
+    val result = createInstance<ActualImplementationClass>()
+
+    /* Then */
+    expect(result).toNotBeNull()
+
+    doReturn("Oi!").`when`(result).operation()
+    expect("Oi!") { result.operation() }
+  }
+
+  open class ActualImplementationClass(val s: String) {
+    fun operation(): String {
+      throw IllegalStateException("This should not be called!")
+    }
+  }
+}


### PR DESCRIPTION
There is ClassCastException when using this lib with PowerMock. I added class check before casting inside CreateInstance.kt, which prevents the exception. No PowerMock dependency introduced.

**Problem description**

Exception:
```
java.lang.ClassCastException: com.amazon.identity.auth.device.shared.APIListener$$EnhancerByMockitoWithCGLIB$$6966922d cannot be cast to org.mockito.internal.creation.bytebuddy.MockMethodInterceptor$MockAccess

	at com.nhaarman.mockito_kotlin.CreateInstanceKt.uncheckedMock(CreateInstance.kt:165)
	at com.nhaarman.mockito_kotlin.CreateInstanceKt.createInstance(CreateInstance.kt:55)
        ...
```

Code that caused the exception
```kotlin
@RunWith(PowerMockRunner::class)
class MockitoKotlinPowermockTest {
    @Test fun anyTest() {
        any<APIListener>() // Class cast exception inside
    }
}
```