### PR TITLE
Makes `mock` return non-null types.

### DIFF
--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
@@ -69,10 +69,10 @@ inline fun <reified T : Any> isA() = Mockito.isA(T::class.java)
 inline fun <reified T : Any> isNotNull() = Mockito.isNotNull(T::class.java)
 inline fun <reified T : Any> isNull(): T? = Mockito.isNull(T::class.java)
 
-inline fun <reified T : Any> mock() = Mockito.mock(T::class.java)
-inline fun <reified T : Any> mock(defaultAnswer: Answer<Any>) = Mockito.mock(T::class.java, defaultAnswer)
-inline fun <reified T : Any> mock(s: MockSettings) = Mockito.mock(T::class.java, s)
-inline fun <reified T : Any> mock(s: String) = Mockito.mock(T::class.java, s)
+inline fun <reified T : Any> mock(): T = Mockito.mock(T::class.java)!!
+inline fun <reified T : Any> mock(defaultAnswer: Answer<Any>): T = Mockito.mock(T::class.java, defaultAnswer)!!
+inline fun <reified T : Any> mock(s: MockSettings): T = Mockito.mock(T::class.java, s)!!
+inline fun <reified T : Any> mock(s: String): T = Mockito.mock(T::class.java, s)!!
 
 fun mockingDetails(toInspect: Any) = Mockito.mockingDetails(toInspect)
 fun never() = Mockito.never()


### PR DESCRIPTION
Thank you for submitting a pull request! But first:

 - [x] Can you back your code up with tests?
 - [x] Keep your commits clean: [squash your commits if necessary](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History).
 - [x] Make sure you're targeting the `dev` branch with the PR.

Since `Mockito.mock` is a Java function it returns a Kotlin platform type.  By adding an explicit return type to the wrapper, the kotlin version of `mock` will now return a non-platform type.  In this case, we know that `Mockito.mock` doesn't return null so we can safely make the wrapper return a non-null type.  We add the `!!` to make it clear to the reader our intent is to strip the platform type at this point, and also make the Kotlin compiler add an explicit null-check "just in case" before returning from the kotlin `mock` method.