### PR TITLE
Release 0.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ For example:
 verify(myClass).setItems(argThat{ size == 2 })
 ```
 
+### Argument Captors
+
+Argument Captors can be used to capture argument values for further assertions.
+For example:
+
+```kotlin
+verify(myClass).setItems(capture { items ->
+  assertEquals(2, items.size)
+  assertEquals("test", items[0])
+})
+```
+
 ### Convenience functions
 
 Most of Mockito's static functions are available as top-level functions.

--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'kotlin'
 
 buildscript {
-  ext.kotlin_version = '1.0.2-1'
+  ext.kotlin_version = '1.0.3'
 
   repositories {
     mavenCentral()

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
@@ -25,11 +25,17 @@
 
 package com.nhaarman.mockito_kotlin
 
+import org.mockito.InOrder
 import org.mockito.MockSettings
+import org.mockito.MockingDetails
 import org.mockito.Mockito
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
+import org.mockito.stubbing.DeprecatedOngoingStubbing
+import org.mockito.stubbing.OngoingStubbing
+import org.mockito.stubbing.Stubber
 import org.mockito.verification.VerificationMode
+import org.mockito.verification.VerificationWithTimeout
 import kotlin.reflect.KClass
 
 fun after(millis: Long) = Mockito.after(millis)
@@ -44,29 +50,29 @@ inline fun <reified T : Any> anyVararg() = Mockito.anyVararg<T>() ?: createInsta
 
 inline fun <reified T : Any> argThat(noinline predicate: T.() -> Boolean) = Mockito.argThat<T> { it -> (it as T).predicate() } ?: createInstance(T::class)
 
-fun atLeast(numInvocations: Int) = Mockito.atLeast(numInvocations)
-fun atLeastOnce() = Mockito.atLeastOnce()
-fun atMost(maxNumberOfInvocations: Int) = Mockito.atMost(maxNumberOfInvocations)
-fun calls(wantedNumberOfInvocations: Int) = Mockito.calls(wantedNumberOfInvocations)
+fun atLeast(numInvocations: Int): VerificationMode = Mockito.atLeast(numInvocations)!!
+fun atLeastOnce(): VerificationMode = Mockito.atLeastOnce()!!
+fun atMost(maxNumberOfInvocations: Int): VerificationMode = Mockito.atMost(maxNumberOfInvocations)!!
+fun calls(wantedNumberOfInvocations: Int): VerificationMode = Mockito.calls(wantedNumberOfInvocations)!!
 
 fun <T> clearInvocations(vararg mocks: T) = Mockito.clearInvocations(*mocks)
-fun description(description: String) = Mockito.description(description)
+fun description(description: String): VerificationMode = Mockito.description(description)
 
-fun <T> doAnswer(answer: (InvocationOnMock) -> T?) = Mockito.doAnswer { answer(it) }
+fun <T> doAnswer(answer: (InvocationOnMock) -> T?): Stubber = Mockito.doAnswer { answer(it) }!!
 
-fun doCallRealMethod() = Mockito.doCallRealMethod()
-fun doNothing() = Mockito.doNothing()
-fun doReturn(value: Any) = Mockito.doReturn(value)
-fun doReturn(toBeReturned: Any, vararg toBeReturnedNext: Any) = Mockito.doReturn(toBeReturned, *toBeReturnedNext)
-fun doThrow(toBeThrown: KClass<out Throwable>) = Mockito.doThrow(toBeThrown.java)
-fun doThrow(vararg toBeThrown: Throwable) = Mockito.doThrow(*toBeThrown)
+fun doCallRealMethod(): Stubber = Mockito.doCallRealMethod()!!
+fun doNothing(): Stubber = Mockito.doNothing()!!
+fun doReturn(value: Any): Stubber = Mockito.doReturn(value)!!
+fun doReturn(toBeReturned: Any, vararg toBeReturnedNext: Any): Stubber = Mockito.doReturn(toBeReturned, *toBeReturnedNext)!!
+fun doThrow(toBeThrown: KClass<out Throwable>): Stubber = Mockito.doThrow(toBeThrown.java)!!
+fun doThrow(vararg toBeThrown: Throwable): Stubber = Mockito.doThrow(*toBeThrown)!!
 
-inline fun <reified T : Any> eq(value: T) = Mockito.eq(value) ?: createInstance<T>()
-fun ignoreStubs(vararg mocks: Any) = Mockito.ignoreStubs(*mocks)
-fun inOrder(vararg mocks: Any) = Mockito.inOrder(*mocks)
+inline fun <reified T : Any> eq(value: T): T = Mockito.eq(value) ?: createInstance<T>()
+fun ignoreStubs(vararg mocks: Any): Array<out Any> = Mockito.ignoreStubs(*mocks)!!
+fun inOrder(vararg mocks: Any): InOrder = Mockito.inOrder(*mocks)!!
 
-inline fun <reified T : Any> isA() = Mockito.isA(T::class.java)
-inline fun <reified T : Any> isNotNull() = Mockito.isNotNull(T::class.java)
+inline fun <reified T : Any> isA(): T? = Mockito.isA(T::class.java)
+inline fun <reified T : Any> isNotNull(): T? = Mockito.isNotNull(T::class.java)
 inline fun <reified T : Any> isNull(): T? = Mockito.isNull(T::class.java)
 
 inline fun <reified T : Any> mock(): T = Mockito.mock(T::class.java)!!
@@ -74,29 +80,28 @@ inline fun <reified T : Any> mock(defaultAnswer: Answer<Any>): T = Mockito.mock(
 inline fun <reified T : Any> mock(s: MockSettings): T = Mockito.mock(T::class.java, s)!!
 inline fun <reified T : Any> mock(s: String): T = Mockito.mock(T::class.java, s)!!
 
-fun mockingDetails(toInspect: Any) = Mockito.mockingDetails(toInspect)
-fun never() = Mockito.never()
-inline fun <reified T : Any> notNull() = Mockito.notNull(T::class.java)
-fun only() = Mockito.only()
-fun <T> refEq(value: T, vararg excludeFields: String) = Mockito.refEq(value, *excludeFields)
+fun mockingDetails(toInspect: Any): MockingDetails = Mockito.mockingDetails(toInspect)!!
+fun never(): VerificationMode = Mockito.never()!!
+inline fun <reified T : Any> notNull(): T? = Mockito.notNull(T::class.java)
+fun only(): VerificationMode = Mockito.only()!!
+fun <T> refEq(value: T, vararg excludeFields: String): T? = Mockito.refEq(value, *excludeFields)
 
-fun reset() = Mockito.reset<Any>()
 fun <T> reset(vararg mocks: T) = Mockito.reset(*mocks)
 
-fun <T> same(value: T) = Mockito.same(value)
+fun <T> same(value: T): T? = Mockito.same(value)
 
-inline fun <reified T : Any> spy() = Mockito.spy(T::class.java)
-fun <T> spy(value: T) = Mockito.spy(value)
+inline fun <reified T : Any> spy(): T = Mockito.spy(T::class.java)!!
+fun <T> spy(value: T): T = Mockito.spy(value)!!
 
-fun <T> stub(methodCall: T) = Mockito.stub(methodCall)
-fun timeout(millis: Long) = Mockito.timeout(millis)
-fun times(numInvocations: Int) = Mockito.times(numInvocations)
+fun <T> stub(methodCall: T): DeprecatedOngoingStubbing<T> = Mockito.stub(methodCall)!!
+fun timeout(millis: Long): VerificationWithTimeout = Mockito.timeout(millis)!!
+fun times(numInvocations: Int): VerificationMode = Mockito.times(numInvocations)!!
 fun validateMockitoUsage() = Mockito.validateMockitoUsage()
 
-fun <T> verify(mock: T) = Mockito.verify(mock)
-fun <T> verify(mock: T, mode: VerificationMode) = Mockito.verify(mock, mode)
+fun <T> verify(mock: T): T = Mockito.verify(mock)!!
+fun <T> verify(mock: T, mode: VerificationMode): T = Mockito.verify(mock, mode)!!
 fun <T> verifyNoMoreInteractions(vararg mocks: T) = Mockito.verifyNoMoreInteractions(*mocks)
 fun verifyZeroInteractions(vararg mocks: Any) = Mockito.verifyZeroInteractions(*mocks)
 
-fun <T> whenever(methodCall: T) = Mockito.`when`(methodCall)
-fun withSettings() = Mockito.withSettings()
+fun <T> whenever(methodCall: T): OngoingStubbing<T> = Mockito.`when`(methodCall)!!
+fun withSettings(): MockSettings = Mockito.withSettings()!!

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
@@ -62,8 +62,8 @@ fun <T> doAnswer(answer: (InvocationOnMock) -> T?): Stubber = Mockito.doAnswer {
 
 fun doCallRealMethod(): Stubber = Mockito.doCallRealMethod()!!
 fun doNothing(): Stubber = Mockito.doNothing()!!
-fun doReturn(value: Any): Stubber = Mockito.doReturn(value)!!
-fun doReturn(toBeReturned: Any, vararg toBeReturnedNext: Any): Stubber = Mockito.doReturn(toBeReturned, *toBeReturnedNext)!!
+fun doReturn(value: Any?): Stubber = Mockito.doReturn(value)!!
+fun doReturn(toBeReturned: Any?, vararg toBeReturnedNext: Any?): Stubber = Mockito.doReturn(toBeReturned, *toBeReturnedNext)!!
 fun doThrow(toBeThrown: KClass<out Throwable>): Stubber = Mockito.doThrow(toBeThrown.java)!!
 fun doThrow(vararg toBeThrown: Throwable): Stubber = Mockito.doThrow(*toBeThrown)!!
 

--- a/mockito-kotlin/src/test/kotlin/MockitoTest.kt
+++ b/mockito-kotlin/src/test/kotlin/MockitoTest.kt
@@ -231,6 +231,25 @@ class MockitoTest {
     }
 
     @Test
+    fun testDoReturnNullValue() {
+        val mock = mock<Methods>()
+
+        doReturn(null).whenever(mock).stringResult()
+
+        expect(mock.stringResult()).toBeNull()
+    }
+
+    @Test
+    fun testDoReturnNullValues() {
+        val mock = mock<Methods>()
+
+        doReturn(null, null).whenever(mock).stringResult()
+
+        expect(mock.stringResult()).toBeNull()
+        expect(mock.stringResult()).toBeNull()
+    }
+
+    @Test
     fun testDoReturnValues() {
         val mock = mock<Methods>()
 


### PR DESCRIPTION
 - Updates the Kotlin version to `1.0.3` (#51)
 - Use explicit return types for calls to Mockito (#50)
 - `doReturn` accepts `null` values (#34)