### PR TITLE
Upgrade Mockito to 2.0.99-beta

### DIFF
--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -20,7 +20,7 @@ repositories {
 dependencies {
   compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-  compile "org.mockito:mockito-core:2.0.52-beta"
+  compile "org.mockito:mockito-core:2.0.99-beta"
 
   /* Tests */
   testCompile "junit:junit:4.12"

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/CreateInstance.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/CreateInstance.kt
@@ -177,7 +177,7 @@ private fun <T : Any> KType.createNullableInstance(): T? {
 private fun <T> Class<T>.uncheckedMock(): T {
     val impl = MockSettingsImpl<T>().defaultAnswer(Answers.RETURNS_DEFAULTS) as MockSettingsImpl<T>
     val creationSettings = impl.confirm(this)
-    return MockUtil().createMock(creationSettings).apply {
+    return MockUtil.createMock(creationSettings).apply {
         (this as MockMethodInterceptor.MockAccess).mockitoInterceptor = null
     }
 }

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
@@ -31,7 +31,6 @@ import org.mockito.MockingDetails
 import org.mockito.Mockito
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
-import org.mockito.stubbing.DeprecatedOngoingStubbing
 import org.mockito.stubbing.OngoingStubbing
 import org.mockito.stubbing.Stubber
 import org.mockito.verification.VerificationMode
@@ -93,7 +92,6 @@ fun <T> same(value: T): T? = Mockito.same(value)
 inline fun <reified T : Any> spy(): T = Mockito.spy(T::class.java)!!
 fun <T> spy(value: T): T = Mockito.spy(value)!!
 
-fun <T> stub(methodCall: T): DeprecatedOngoingStubbing<T> = Mockito.stub(methodCall)!!
 fun timeout(millis: Long): VerificationWithTimeout = Mockito.timeout(millis)!!
 fun times(numInvocations: Int): VerificationMode = Mockito.times(numInvocations)!!
 fun validateMockitoUsage() = Mockito.validateMockitoUsage()


### PR DESCRIPTION
Recent versions of Mockito break with mockito-kotlin because of changes in mockito/mockito#404:

* org.mockito.internal.util.MockUtil is now a static utility class
* org.mockito.Mockito#stub has been removed in favor of #when

This change updates mockito-kotlin to not instantiate MockUtil and aliases `com.nhaarman.mockito_kotlin.stub` to `com.nhaarman.mockito_kotlin.whenever`, which was suggested by the docs. 

I think it may be better to remove the stub method all together, since Mockito has chosen to do that, but figured this was a safer starting point. Happy to update the PR if that's the better route.

---

Thank you for submitting a pull request! But first:

 - [x] Can you back your code up with tests? *Underlying Mockito API changes; all existing tests pass*
 - [x] Keep your commits clean: [squash your commits if necessary](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History).
 - [x] Make sure you're targeting the `dev` branch with the PR.