### PR TITLE
Accept a stubbing lambda in mock()

### DIFF
--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
@@ -79,6 +79,17 @@ inline fun <reified T : Any> mock(defaultAnswer: Answer<Any>): T = Mockito.mock(
 inline fun <reified T : Any> mock(s: MockSettings): T = Mockito.mock(T::class.java, s)!!
 inline fun <reified T : Any> mock(s: String): T = Mockito.mock(T::class.java, s)!!
 
+inline fun <reified T : Any> mock(stubbing: KStubbing<T>.() -> Unit): T
+        = Mockito.mock(T::class.java)!!.apply { stubbing(KStubbing(this)) }
+
+class KStubbing<out T>(private val mock: T) {
+    fun <R> on(methodCall: R) = Mockito.`when`(methodCall)
+    fun <R> on(methodCall: T.() -> R) = Mockito.`when`(mock.methodCall())
+}
+
+fun <T> OngoingStubbing<T>.doReturn(t: T) = thenReturn(t)
+fun <T> OngoingStubbing<T>.doReturn(t: T, vararg ts: T) = thenReturn(t, *ts)
+
 fun mockingDetails(toInspect: Any): MockingDetails = Mockito.mockingDetails(toInspect)!!
 fun never(): VerificationMode = Mockito.never()!!
 inline fun <reified T : Any> notNull(): T? = Mockito.notNull(T::class.java)

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
@@ -87,8 +87,9 @@ class KStubbing<out T>(private val mock: T) {
     fun <R> on(methodCall: T.() -> R) = Mockito.`when`(mock.methodCall())
 }
 
-fun <T> OngoingStubbing<T>.doReturn(t: T) = thenReturn(t)
-fun <T> OngoingStubbing<T>.doReturn(t: T, vararg ts: T) = thenReturn(t, *ts)
+infix fun <T> OngoingStubbing<T>.doReturn(t: T): OngoingStubbing<T> = thenReturn(t)
+fun <T> OngoingStubbing<T>.doReturn(t: T, vararg ts: T): OngoingStubbing<T> = thenReturn(t, *ts)
+inline infix fun <reified T> OngoingStubbing<T>.doReturn(ts: List<T>): OngoingStubbing<T> = thenReturn(ts[0], *ts.drop(1).toTypedArray())
 
 fun mockingDetails(toInspect: Any): MockingDetails = Mockito.mockingDetails(toInspect)!!
 fun never(): VerificationMode = Mockito.never()!!

--- a/mockito-kotlin/src/test/kotlin/MockitoTest.kt
+++ b/mockito-kotlin/src/test/kotlin/MockitoTest.kt
@@ -282,4 +282,48 @@ class MockitoTest {
             mock.go()
         }
     }
+
+    @Test
+    fun testMockStubbing_lambda() {
+        /* Given */
+        val mock = mock<Open>() {
+            on { stringResult() }.doReturn("A")
+        }
+
+        /* When */
+        val result = mock.stringResult()
+
+        /* Then */
+        expect(result).toBe("A")
+    }
+
+    @Test
+    fun testMockStubbing_normalOverridesLambda() {
+        /* Given */
+        val mock = mock<Open>() {
+            on { stringResult() }.doReturn("A")
+        }
+        whenever(mock.stringResult()).thenReturn("B")
+
+        /* When */
+        val result = mock.stringResult()
+
+        /* Then */
+        expect(result).toBe("B")
+    }
+
+    @Test
+    fun testMockStubbing_methodCall() {
+        /* Given */
+        val mock = mock<Open>()
+        mock<Open> {
+            on(mock.stringResult()).doReturn("A")
+        }
+
+        /* When */
+        val result = mock.stringResult()
+
+        /* Then */
+        expect(result).toBe("A")
+    }
 }

--- a/mockito-kotlin/src/test/kotlin/MockitoTest.kt
+++ b/mockito-kotlin/src/test/kotlin/MockitoTest.kt
@@ -287,7 +287,7 @@ class MockitoTest {
     fun testMockStubbing_lambda() {
         /* Given */
         val mock = mock<Open>() {
-            on { stringResult() }.doReturn("A")
+            on { stringResult() } doReturn "A"
         }
 
         /* When */
@@ -325,5 +325,17 @@ class MockitoTest {
 
         /* Then */
         expect(result).toBe("A")
+    }
+
+    @Test
+    fun doReturn_withSingleItemList() {
+        /* Given */
+        val mock = mock<Open> {
+            on { stringResult() } doReturn listOf("a", "b")
+        }
+
+        /* Then */
+        expect(mock.stringResult()).toBe("a")
+        expect(mock.stringResult()).toBe("b")
     }
 }


### PR DESCRIPTION
Fixes #47.

Calls to `mock()` can now pass a lambda that allows for easy stubbing:

```kotlin
interface MyInterface {
    fun text() : String
}

val mock = mock<MyInterface> {
    on { text() } doReturn "test"
   on { test() }.doReturn("test")
}
```