### PR TITLE
Bump Kotlin version

### DIFF
--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'kotlin'
 
 buildscript {
-  ext.kotlin_version = '1.0.3'
+  ext.kotlin_version = '1.0.4'
 
   repositories {
     mavenCentral()


### PR DESCRIPTION
Kotlin [1.0.4](https://blog.jetbrains.com/kotlin/2016/09/kotlin-1-0-4-is-here/) was released a few days ago.

This PR updates the Kotlin version correspondingly. 
