### PR TITLE
Release 0.7.0

### DIFF
--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'kotlin'
 
 buildscript {
-  ext.kotlin_version = '1.0.3'
+  ext.kotlin_version = '1.0.4'
 
   repositories {
     mavenCentral()

--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -20,7 +20,7 @@ repositories {
 dependencies {
   compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-  compile "org.mockito:mockito-core:2.1.0-RC.1"
+  compile "org.mockito:mockito-core:2.1.0"
 
   /* Tests */
   testCompile "junit:junit:4.12"

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/CreateInstance.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/CreateInstance.kt
@@ -27,7 +27,7 @@ package com.nhaarman.mockito_kotlin
 
 import org.mockito.Answers
 import org.mockito.internal.creation.MockSettingsImpl
-import org.mockito.internal.creation.bytebuddy.MockMethodInterceptor
+import org.mockito.internal.creation.bytebuddy.MockAccess
 import org.mockito.internal.util.MockUtil
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Modifier
@@ -172,6 +172,6 @@ private fun <T> Class<T>.uncheckedMock(): T {
     val impl = MockSettingsImpl<T>().defaultAnswer(Answers.RETURNS_DEFAULTS) as MockSettingsImpl<T>
     val creationSettings = impl.confirm(this)
     return MockUtil.createMock(creationSettings).apply {
-        (this as MockMethodInterceptor.MockAccess).mockitoInterceptor = null
+        (this as MockAccess).mockitoInterceptor = null
     }
 }

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
@@ -41,12 +41,16 @@ fun after(millis: Long) = Mockito.after(millis)
 
 /** Matches any object, excluding nulls. */
 inline fun <reified T : Any> any() = Mockito.any(T::class.java) ?: createInstance<T>()
+
 /** Matches anything, including nulls. */
 inline fun <reified T : Any> anyOrNull(): T = Mockito.any<T>() ?: createInstance<T>()
+
 /** Matches any vararg object, including nulls. */
 inline fun <reified T : Any> anyVararg(): T = Mockito.any<T>() ?: createInstance<T>()
+
 /** Matches any array of type T. */
 inline fun <reified T : Any?> anyArray(): Array<T> = Mockito.any(Array<T>::class.java) ?: arrayOf()
+
 inline fun <reified T : Any> argThat(noinline predicate: T.() -> Boolean) = Mockito.argThat<T> { it -> (it as T).predicate() } ?: createInstance(T::class)
 inline fun <reified T : Any> argForWhich(noinline predicate: T.() -> Boolean) = argThat(predicate)
 
@@ -80,8 +84,11 @@ inline fun <reified T : Any> mock(defaultAnswer: Answer<Any>): T = Mockito.mock(
 inline fun <reified T : Any> mock(s: MockSettings): T = Mockito.mock(T::class.java, s)!!
 inline fun <reified T : Any> mock(s: String): T = Mockito.mock(T::class.java, s)!!
 
-inline fun <reified T : Any> mock(stubbing: KStubbing<T>.() -> Unit): T
-        = Mockito.mock(T::class.java)!!.apply { stubbing(KStubbing(this)) }
+inline fun <reified T : Any> mock(stubbing: KStubbing<T>.(T) -> Unit): T {
+    return mock<T>().apply {
+        KStubbing(this).stubbing(this)
+    }
+}
 
 class KStubbing<out T>(private val mock: T) {
     fun <R> on(methodCall: R) = Mockito.`when`(methodCall)

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/MockitoKotlin.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/MockitoKotlin.kt
@@ -78,6 +78,8 @@ class MockitoKotlin {
                     ?.second
         }
 
-        private fun StackTraceElement.toFileIdentifier() = "$fileName$className"
+        private fun StackTraceElement.toFileIdentifier() = "$fileName$className".let {
+            if (it.contains("$")) it.substring(0..it.indexOf("$") - 1) else it
+        }
     }
 }

--- a/mockito-kotlin/src/test/kotlin/Classes.kt
+++ b/mockito-kotlin/src/test/kotlin/Classes.kt
@@ -54,6 +54,7 @@ interface Methods {
     fun nullableString(s: String?)
 
     fun stringResult(): String
+    fun builderMethod() : Methods
 }
 
 class ThrowableClass(cause: Throwable) : Throwable(cause)

--- a/mockito-kotlin/src/test/kotlin/MockitoKotlinTest.kt
+++ b/mockito-kotlin/src/test/kotlin/MockitoKotlinTest.kt
@@ -24,11 +24,16 @@
  */
 
 import com.nhaarman.expect.expect
-import com.nhaarman.mockito_kotlin.MockitoKotlin
-import com.nhaarman.mockito_kotlin.createInstance
+import com.nhaarman.mockito_kotlin.*
+import org.junit.After
 import org.junit.Test
 
 class MockitoKotlinTest {
+
+    @After
+    fun teardown() {
+        MockitoKotlin.resetInstanceCreators()
+    }
 
     @Test
     fun register() {
@@ -55,5 +60,19 @@ class MockitoKotlinTest {
 
         /* Then */
         expect(result).toNotBeTheSameAs(closed)
+    }
+
+    @Test
+    fun usingInstanceCreatorInsideLambda() {
+        MockitoKotlin.registerInstanceCreator { CreateInstanceTest.ForbiddenConstructor(2) }
+
+        mock<TestClass> {
+            on { doSomething(any()) } doReturn ""
+        }
+    }
+
+    interface TestClass {
+
+        fun doSomething(c: CreateInstanceTest.ForbiddenConstructor): String
     }
 }

--- a/mockito-kotlin/src/test/kotlin/MockitoTest.kt
+++ b/mockito-kotlin/src/test/kotlin/MockitoTest.kt
@@ -362,6 +362,20 @@ class MockitoTest {
     }
 
     @Test
+    fun testMockStubbing_builder() {
+        /* Given */
+        val mock = mock<Methods> { mock ->
+            on { builderMethod() } doReturn mock
+        }
+
+        /* When */
+        val result = mock.builderMethod()
+
+        /* Then */
+        expect(result).toBeTheSameAs(mock)
+    }
+
+    @Test
     fun doReturn_withSingleItemList() {
         /* Given */
         val mock = mock<Open> {


### PR DESCRIPTION
 - Upgrades Kotlin to 1.0.4
 - Upgrades Mockito to 2.1.0
 - Provides mock instance to stubbing method in `mock()`
 - Fixes issue where the use of `any()` in lambdas in combination with instance creators would not work (#81)