### PR TITLE
enable mocking final classes by default

### DIFF
--- a/mockito-kotlin/src/main/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/mockito-kotlin/src/main/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
see: http://hadihariri.com/2016/10/04/Mocking-Kotlin-With-Mockito/
I placed it in src and not test because the lib is used with test
dependency itself. if it will be in test other projects will not be
getting the resource.