### PR TITLE
Added doThrow methods to OngoingStubbing

### DIFF
--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
@@ -99,6 +99,11 @@ infix fun <T> OngoingStubbing<T>.doReturn(t: T): OngoingStubbing<T> = thenReturn
 fun <T> OngoingStubbing<T>.doReturn(t: T, vararg ts: T): OngoingStubbing<T> = thenReturn(t, *ts)
 inline infix fun <reified T> OngoingStubbing<T>.doReturn(ts: List<T>): OngoingStubbing<T> = thenReturn(ts[0], *ts.drop(1).toTypedArray())
 
+infix fun <T> OngoingStubbing<T>.doThrow(t: Throwable): OngoingStubbing<T> = thenThrow(t)
+fun <T> OngoingStubbing<T>.doThrow(t: Throwable, vararg ts: Throwable): OngoingStubbing<T> = thenThrow(t, *ts)
+infix fun <T> OngoingStubbing<T>.doThrow(t: KClass<out Throwable>): OngoingStubbing<T> = thenThrow(t.java)
+fun <T> OngoingStubbing<T>.doThrow(t: KClass<out Throwable>, vararg ts: KClass<out Throwable>): OngoingStubbing<T> = thenThrow(t.java, *ts.map { it.java }.toTypedArray())
+
 fun mockingDetails(toInspect: Any): MockingDetails = Mockito.mockingDetails(toInspect)!!
 fun never(): VerificationMode = Mockito.never()!!
 fun <T : Any> notNull(): T? = Mockito.notNull()

--- a/mockito-kotlin/src/test/kotlin/MockitoTest.kt
+++ b/mockito-kotlin/src/test/kotlin/MockitoTest.kt
@@ -1,5 +1,6 @@
 import com.nhaarman.expect.expect
 import com.nhaarman.expect.expectErrorWithMessage
+import com.nhaarman.expect.fail
 import com.nhaarman.mockito_kotlin.*
 import org.junit.Test
 import org.mockito.exceptions.base.MockitoAssertionError
@@ -374,6 +375,80 @@ class MockitoTest {
 
         /* Then */
         expect(result).toBeTheSameAs(mock)
+    }
+
+    @Test
+    fun testMockStubbing_doThrow() {
+        /* Given */
+        val mock = mock<Methods> { mock ->
+            on { builderMethod() } doThrow IllegalArgumentException()
+        }
+
+        try {
+            /* When */
+            mock.builderMethod()
+            fail("No exception thrown")
+        } catch(e: IllegalArgumentException) {
+        }
+    }
+
+    @Test
+    fun testMockStubbing_doThrowClass() {
+        /* Given */
+        val mock = mock<Methods> { mock ->
+            on { builderMethod() } doThrow IllegalArgumentException::class
+        }
+
+        try {
+            /* When */
+            mock.builderMethod()
+            fail("No exception thrown")
+        } catch(e: IllegalArgumentException) {
+        }
+    }
+
+    @Test
+    fun testMockStubbing_doThrowVarargs() {
+        /* Given */
+        val mock = mock<Methods> { mock ->
+            on { builderMethod() }.doThrow(IllegalArgumentException(), UnsupportedOperationException())
+        }
+
+        try {
+            /* When */
+            mock.builderMethod()
+            fail("No exception thrown")
+        } catch(e: IllegalArgumentException) {
+        }
+
+        try {
+            /* When */
+            mock.builderMethod()
+            fail("No exception thrown")
+        } catch(e: UnsupportedOperationException) {
+        }
+    }
+
+    @Test
+    fun testMockStubbing_doThrowClassVarargs() {
+        /* Given */
+        val mock = mock<Methods> { mock ->
+            on { builderMethod() }.doThrow(IllegalArgumentException::class, UnsupportedOperationException::class)
+        }
+
+        try {
+            /* When */
+            mock.builderMethod()
+            fail("No exception thrown")
+        } catch(e: IllegalArgumentException) {
+        }
+
+        try {
+            /* When */
+            mock.builderMethod()
+            fail("No exception thrown")
+        } catch(e: UnsupportedOperationException) {
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes #89.

```kotlin
on { method() } doThrow IllegalArgumentException()
on { method() } doThrow IllegalArgumentException::class
```