### PR TITLE
Improve argument captors

### DIFF
--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/ArgumentCaptor.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/ArgumentCaptor.kt
@@ -26,9 +26,32 @@
 package com.nhaarman.mockito_kotlin
 
 import org.mockito.ArgumentCaptor
+import kotlin.reflect.KClass
 
-inline fun <reified T : Any> argumentCaptor() = ArgumentCaptor.forClass(T::class.java)
+inline fun <reified T : Any> argumentCaptor(): KArgumentCaptor<T> = KArgumentCaptor(ArgumentCaptor.forClass(T::class.java), T::class)
+
 inline fun <reified T : Any> capture(captor: ArgumentCaptor<T>): T = captor.capture() ?: createInstance<T>()
+
+@Deprecated("Use captor.capture() instead.", ReplaceWith("captor.capture()"))
+inline fun <reified T : Any> capture(captor: KArgumentCaptor<T>): T = captor.capture()
+
+class KArgumentCaptor<out T : Any>(private val captor: ArgumentCaptor<T>, private val tClass: KClass<T>) {
+
+    val value: T
+        get() = captor.value
+
+    val allValues: List<T>
+        get() = captor.allValues
+
+    fun capture(): T = captor.capture() ?: createInstance(tClass)
+}
+
+/**
+ * This method is deprecated because its behavior differs from the Java behavior.
+ * Instead, use [argumentCaptor] in the traditional way, or use one of
+ * [argThat], [argForWhich] or [check].
+ */
+@Deprecated("Use argumentCaptor() or argThat() instead.")
 inline fun <reified T : Any> capture(noinline consumer: (T) -> Unit): T {
     var times = 0
     return argThat { if (++times == 1) consumer.invoke(this); true }

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
@@ -53,6 +53,7 @@ inline fun <reified T : Any?> anyArray(): Array<T> = Mockito.any(Array<T>::class
 
 inline fun <reified T : Any> argThat(noinline predicate: T.() -> Boolean) = Mockito.argThat<T> { it -> (it as T).predicate() } ?: createInstance(T::class)
 inline fun <reified T : Any> argForWhich(noinline predicate: T.() -> Boolean) = argThat(predicate)
+inline fun <reified T : Any> check(noinline predicate: (T) -> Unit) = Mockito.argThat<T> { it -> predicate(it); true } ?: createInstance(T::class)
 
 fun atLeast(numInvocations: Int): VerificationMode = Mockito.atLeast(numInvocations)!!
 fun atLeastOnce(): VerificationMode = Mockito.atLeastOnce()!!

--- a/mockito-kotlin/src/test/kotlin/ArgumentCaptorTest.kt
+++ b/mockito-kotlin/src/test/kotlin/ArgumentCaptorTest.kt
@@ -1,8 +1,8 @@
+import com.nhaarman.expect.expect
 import com.nhaarman.mockito_kotlin.argumentCaptor
 import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.expect.expect
-import com.nhaarman.mockito_kotlin.capture
 import org.junit.Test
 import java.util.*
 
@@ -10,22 +10,30 @@ class ArgumentCaptorTest {
 
     @Test
     fun explicitCaptor() {
+        /* Given */
         val date: Date = mock()
-        val time = argumentCaptor<Long>()
 
+        /* When */
         date.time = 5L
 
-        verify(date).time = capture(time)
-        expect(time.value).toBe(5L)
+        /* Then */
+        val captor = argumentCaptor<Long>()
+        verify(date).time = captor.capture()
+        expect(captor.value).toBe(5L)
     }
 
     @Test
-    fun implicitCaptor() {
+    fun argumentCaptor_multipleValues() {
+        /* Given */
         val date: Date = mock()
-        date.time = 5L
 
-        verify(date).time = capture {
-            expect(it).toBe(5L)
-        }
+        /* When */
+        date.time = 5L
+        date.time = 7L
+
+        /* Then */
+        val captor = argumentCaptor<Long>()
+        verify(date, times(2)).time = captor.capture()
+        expect(captor.allValues).toBe(listOf(5, 7))
     }
 }

--- a/mockito-kotlin/src/test/kotlin/MockitoTest.kt
+++ b/mockito-kotlin/src/test/kotlin/MockitoTest.kt
@@ -163,6 +163,16 @@ class MockitoTest {
     }
 
     @Test
+    fun listArgCheck() {
+        mock<Methods>().apply {
+            closedList(listOf(Closed(), Closed()))
+            verify(this).closedList(check {
+                expect(it.size).toBe(2)
+            })
+        }
+    }
+
+    @Test
     fun atLeastXInvocations() {
         mock<Methods>().apply {
             string("")


### PR DESCRIPTION
Fixes #79.

The capture { } method's behavior did not match
the Java behavior.
For capturing single values, use one of the following:

 - argThat(T.() -> Boolean)
 - argForWhich(T.() -> Boolean)
 - check((T) -> Unit)

For capturing multiple values, use `argumentCaptor()` in
the traditional Java way.