### PR TITLE
Release 0.8.0

### DIFF
--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -42,7 +42,7 @@ test.dependsOn testInlineMockito
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "org.mockito:mockito-core:2.1.0"
+    compile "org.mockito:mockito-core:2.2.1"
 
     /* Tests */
     testCompile "junit:junit:4.12"

--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -1,73 +1,50 @@
 apply plugin: 'kotlin'
+apply from: './publishing.gradle'
 
 buildscript {
-  ext.kotlin_version = '1.0.4'
+    ext.kotlin_version = '1.0.4'
 
-  repositories {
-    mavenCentral()
-  }
+    repositories {
+        mavenCentral()
+    }
 
-  dependencies {
-    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-  }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
 }
 
 repositories {
-  mavenCentral()
-  jcenter()
+    mavenCentral()
+    jcenter()
 }
+
+sourceSets {
+    testInlineMockito {
+        compileClasspath += main.output + test.output
+        runtimeClasspath += main.output + test.output
+    }
+}
+
+configurations {
+    testInlineMockitoCompile.extendsFrom testCompile
+    testInlineMockitoRuntime.extendsFrom testRuntime
+}
+
+// define custom test task for running integration tests
+task testInlineMockito(type: Test) {
+    testClassesDir = sourceSets.testInlineMockito.output.classesDir
+    classpath = sourceSets.testInlineMockito.runtimeClasspath
+}
+
+test.dependsOn testInlineMockito
+
 
 dependencies {
-  compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-  compile "org.mockito:mockito-core:2.1.0"
+    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+    compile "org.mockito:mockito-core:2.1.0"
 
-  /* Tests */
-  testCompile "junit:junit:4.12"
-  testCompile "com.nhaarman:expect.kt:0.6.0"
-}
-
-publishing {
-  publications {
-    MyPublication(MavenPublication) {
-      from components.java
-      artifact javadocJar
-      artifact sourcesJar
-
-      groupId 'com.nhaarman'
-      artifactId 'mockito-kotlin'
-      version rootProject.ext.versionName
-    }
-  }
-}
-
-bintray {
-  user = hasProperty('bintray_user') ? bintray_user : System.getenv('BINTRAY_USER')
-  key = hasProperty('bintray_key') ? bintray_key : System.getenv('BINTRAY_KEY')
-  publications = ['MyPublication']
-
-  pkg {
-    repo = 'maven'
-    name = "Mockito-Kotlin"
-    desc = "Using Mockito with Kotlin"
-
-    licenses = ['MIT']
-    vcsUrl = 'https://github.com/bintray/gradle-bintray-plugin.git'
-
-    version {
-      name = rootProject.ext.versionName
-      desc = 'Using Mockito with Kotlin'
-      vcsTag = rootProject.ext.versionName
-    }
-  }
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-  classifier = 'javadoc'
-  from 'build/docs/javadoc'
-}
-
-task sourcesJar(type: Jar) {
-  from sourceSets.main.allSource
-  classifier = 'sources'
+    /* Tests */
+    testCompile "junit:junit:4.12"
+    testCompile "com.nhaarman:expect.kt:0.6.0"
 }

--- a/mockito-kotlin/publishing.gradle
+++ b/mockito-kotlin/publishing.gradle
@@ -1,0 +1,44 @@
+publishing {
+    publications {
+        MyPublication(MavenPublication) {
+            from components.java
+            artifact javadocJar
+            artifact sourcesJar
+
+            groupId 'com.nhaarman'
+            artifactId 'mockito-kotlin'
+            version rootProject.ext.versionName
+        }
+    }
+}
+
+bintray {
+    user = hasProperty('bintray_user') ? bintray_user : System.getenv('BINTRAY_USER')
+    key = hasProperty('bintray_key') ? bintray_key : System.getenv('BINTRAY_KEY')
+    publications = ['MyPublication']
+
+    pkg {
+        repo = 'maven'
+        name = "Mockito-Kotlin"
+        desc = "Using Mockito with Kotlin"
+
+        licenses = ['MIT']
+        vcsUrl = 'https://github.com/bintray/gradle-bintray-plugin.git'
+
+        version {
+            name = rootProject.ext.versionName
+            desc = 'Using Mockito with Kotlin'
+            vcsTag = rootProject.ext.versionName
+        }
+    }
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from 'build/docs/javadoc'
+}
+
+task sourcesJar(type: Jar) {
+    from sourceSets.main.allSource
+    classifier = 'sources'
+}

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/ArgumentCaptor.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/ArgumentCaptor.kt
@@ -26,9 +26,32 @@
 package com.nhaarman.mockito_kotlin
 
 import org.mockito.ArgumentCaptor
+import kotlin.reflect.KClass
 
-inline fun <reified T : Any> argumentCaptor() = ArgumentCaptor.forClass(T::class.java)
+inline fun <reified T : Any> argumentCaptor(): KArgumentCaptor<T> = KArgumentCaptor(ArgumentCaptor.forClass(T::class.java), T::class)
+
 inline fun <reified T : Any> capture(captor: ArgumentCaptor<T>): T = captor.capture() ?: createInstance<T>()
+
+@Deprecated("Use captor.capture() instead.", ReplaceWith("captor.capture()"))
+inline fun <reified T : Any> capture(captor: KArgumentCaptor<T>): T = captor.capture()
+
+class KArgumentCaptor<out T : Any>(private val captor: ArgumentCaptor<T>, private val tClass: KClass<T>) {
+
+    val value: T
+        get() = captor.value
+
+    val allValues: List<T>
+        get() = captor.allValues
+
+    fun capture(): T = captor.capture() ?: createInstance(tClass)
+}
+
+/**
+ * This method is deprecated because its behavior differs from the Java behavior.
+ * Instead, use [argumentCaptor] in the traditional way, or use one of
+ * [argThat], [argForWhich] or [check].
+ */
+@Deprecated("Use argumentCaptor() or argThat() instead.")
 inline fun <reified T : Any> capture(noinline consumer: (T) -> Unit): T {
     var times = 0
     return argThat { if (++times == 1) consumer.invoke(this); true }

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/CreateInstance.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/CreateInstance.kt
@@ -29,6 +29,7 @@ import org.mockito.Answers
 import org.mockito.internal.creation.MockSettingsImpl
 import org.mockito.internal.creation.bytebuddy.MockAccess
 import org.mockito.internal.util.MockUtil
+import java.io.File
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Modifier
 import java.lang.reflect.ParameterizedType
@@ -45,6 +46,18 @@ import kotlin.reflect.jvm.jvmName
  * A collection of functions that tries to create an instance of
  * classes to avoid NPE's when using Mockito with Kotlin.
  */
+
+/**
+ * Checks whether the resource file to enable mocking of final classes is present.
+ */
+private var mockMakerInlineEnabled: Boolean? = null
+private fun mockMakerInlineEnabled(jClass: Class<out Any>): Boolean {
+    return mockMakerInlineEnabled ?:
+            jClass.getResource("mockito-extensions/org.mockito.plugins.MockMaker")?.let {
+                mockMakerInlineEnabled = File(it.file).readLines().filter { it == "mock-maker-inline" }.isNotEmpty()
+                mockMakerInlineEnabled
+            } ?: false
+}
 
 inline fun <reified T> createArrayInstance() = arrayOf<T>()
 
@@ -81,7 +94,10 @@ private fun <T> List<KFunction<T>>.withoutArrayParameters() = filter {
 @Suppress("SENSELESS_COMPARISON")
 private fun KClass<*>.hasObjectInstance() = objectInstance != null
 
-private fun KClass<*>.isMockable() = !Modifier.isFinal(java.modifiers)
+private fun KClass<*>.isMockable(): Boolean {
+    return !Modifier.isFinal(java.modifiers) || mockMakerInlineEnabled(java)
+}
+
 private fun KClass<*>.isEnum() = java.isEnum
 private fun KClass<*>.isArray() = java.isArray
 private fun KClass<*>.isClassObject() = jvmName.equals("java.lang.Class")
@@ -168,10 +184,10 @@ private fun <T : Any> KType.createNullableInstance(): T? {
  * Creates a mock instance of given class, without modifying or checking any internal Mockito state.
  */
 @Suppress("UNCHECKED_CAST")
-private fun <T> Class<T>.uncheckedMock(): T {
+fun <T> Class<T>.uncheckedMock(): T {
     val impl = MockSettingsImpl<T>().defaultAnswer(Answers.RETURNS_DEFAULTS) as MockSettingsImpl<T>
     val creationSettings = impl.confirm(this)
     return MockUtil.createMock(creationSettings).apply {
-        (this as MockAccess).mockitoInterceptor = null
+        (this as? MockAccess)?.mockitoInterceptor = null
     }
 }

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/CreateInstance.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/CreateInstance.kt
@@ -41,6 +41,7 @@ import kotlin.reflect.defaultType
 import kotlin.reflect.jvm.isAccessible
 import kotlin.reflect.jvm.javaType
 import kotlin.reflect.jvm.jvmName
+import java.lang.reflect.Array as JavaArray
 
 /**
  * A collection of functions that tries to create an instance of
@@ -51,6 +52,7 @@ import kotlin.reflect.jvm.jvmName
  * Checks whether the resource file to enable mocking of final classes is present.
  */
 private var mockMakerInlineEnabled: Boolean? = null
+
 private fun mockMakerInlineEnabled(jClass: Class<out Any>): Boolean {
     return mockMakerInlineEnabled ?:
             jClass.getResource("mockito-extensions/org.mockito.plugins.MockMaker")?.let {
@@ -137,7 +139,10 @@ private fun <T : Any> KClass<T>.toArrayInstance(): T {
         "LongArray" -> longArrayOf()
         "DoubleArray" -> doubleArrayOf()
         "FloatArray" -> floatArrayOf()
-        else -> throw UnsupportedOperationException("Cannot create a generic array for $simpleName. Use createArrayInstance() or anyArray() instead.")
+        else -> {
+            val name = java.name.drop(2).dropLast(1)
+            return JavaArray.newInstance(Class.forName(name), 0) as T
+        }
     } as T
 }
 

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
@@ -99,6 +99,11 @@ infix fun <T> OngoingStubbing<T>.doReturn(t: T): OngoingStubbing<T> = thenReturn
 fun <T> OngoingStubbing<T>.doReturn(t: T, vararg ts: T): OngoingStubbing<T> = thenReturn(t, *ts)
 inline infix fun <reified T> OngoingStubbing<T>.doReturn(ts: List<T>): OngoingStubbing<T> = thenReturn(ts[0], *ts.drop(1).toTypedArray())
 
+infix fun <T> OngoingStubbing<T>.doThrow(t: Throwable): OngoingStubbing<T> = thenThrow(t)
+fun <T> OngoingStubbing<T>.doThrow(t: Throwable, vararg ts: Throwable): OngoingStubbing<T> = thenThrow(t, *ts)
+infix fun <T> OngoingStubbing<T>.doThrow(t: KClass<out Throwable>): OngoingStubbing<T> = thenThrow(t.java)
+fun <T> OngoingStubbing<T>.doThrow(t: KClass<out Throwable>, vararg ts: KClass<out Throwable>): OngoingStubbing<T> = thenThrow(t.java, *ts.map { it.java }.toTypedArray())
+
 fun mockingDetails(toInspect: Any): MockingDetails = Mockito.mockingDetails(toInspect)!!
 fun never(): VerificationMode = Mockito.never()!!
 fun <T : Any> notNull(): T? = Mockito.notNull()

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
@@ -53,6 +53,7 @@ inline fun <reified T : Any?> anyArray(): Array<T> = Mockito.any(Array<T>::class
 
 inline fun <reified T : Any> argThat(noinline predicate: T.() -> Boolean) = Mockito.argThat<T> { it -> (it as T).predicate() } ?: createInstance(T::class)
 inline fun <reified T : Any> argForWhich(noinline predicate: T.() -> Boolean) = argThat(predicate)
+inline fun <reified T : Any> check(noinline predicate: (T) -> Unit) = Mockito.argThat<T> { it -> predicate(it); true } ?: createInstance(T::class)
 
 fun atLeast(numInvocations: Int): VerificationMode = Mockito.atLeast(numInvocations)!!
 fun atLeastOnce(): VerificationMode = Mockito.atLeastOnce()!!

--- a/mockito-kotlin/src/test/kotlin/ArgumentCaptorTest.kt
+++ b/mockito-kotlin/src/test/kotlin/ArgumentCaptorTest.kt
@@ -1,8 +1,8 @@
+import com.nhaarman.expect.expect
 import com.nhaarman.mockito_kotlin.argumentCaptor
 import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.expect.expect
-import com.nhaarman.mockito_kotlin.capture
 import org.junit.Test
 import java.util.*
 
@@ -10,22 +10,30 @@ class ArgumentCaptorTest {
 
     @Test
     fun explicitCaptor() {
+        /* Given */
         val date: Date = mock()
-        val time = argumentCaptor<Long>()
 
+        /* When */
         date.time = 5L
 
-        verify(date).time = capture(time)
-        expect(time.value).toBe(5L)
+        /* Then */
+        val captor = argumentCaptor<Long>()
+        verify(date).time = captor.capture()
+        expect(captor.value).toBe(5L)
     }
 
     @Test
-    fun implicitCaptor() {
+    fun argumentCaptor_multipleValues() {
+        /* Given */
         val date: Date = mock()
-        date.time = 5L
 
-        verify(date).time = capture {
-            expect(it).toBe(5L)
-        }
+        /* When */
+        date.time = 5L
+        date.time = 7L
+
+        /* Then */
+        val captor = argumentCaptor<Long>()
+        verify(date, times(2)).time = captor.capture()
+        expect(captor.allValues).toBe(listOf(5, 7))
     }
 }

--- a/mockito-kotlin/src/test/kotlin/CreateInstanceTest.kt
+++ b/mockito-kotlin/src/test/kotlin/CreateInstanceTest.kt
@@ -159,10 +159,13 @@ class CreateInstanceTest {
         expect(result).toNotBeNull()
     }
 
-    @Test(expected = UnsupportedOperationException::class)
+    @Test
     fun classArray_usingAny() {
         /* When */
-        createInstance<Array<Open>>()
+        val result = createInstance<Array<Open>>()
+
+        /* Then */
+        expect(result).toBeInstanceOf<Array<Open>>()
     }
 
     @Test

--- a/mockito-kotlin/src/test/kotlin/MockitoTest.kt
+++ b/mockito-kotlin/src/test/kotlin/MockitoTest.kt
@@ -163,6 +163,16 @@ class MockitoTest {
     }
 
     @Test
+    fun listArgCheck() {
+        mock<Methods>().apply {
+            closedList(listOf(Closed(), Closed()))
+            verify(this).closedList(check {
+                expect(it.size).toBe(2)
+            })
+        }
+    }
+
+    @Test
     fun atLeastXInvocations() {
         mock<Methods>().apply {
             string("")

--- a/mockito-kotlin/src/test/kotlin/MockitoTest.kt
+++ b/mockito-kotlin/src/test/kotlin/MockitoTest.kt
@@ -132,6 +132,7 @@ class MockitoTest {
         }
     }
 
+    /** https://github.com/nhaarman/mockito-kotlin/issues/27 */
     @Test
     fun anyThrowableWithSingleThrowableConstructor() {
         mock<Methods>().apply {

--- a/mockito-kotlin/src/test/kotlin/MockitoTest.kt
+++ b/mockito-kotlin/src/test/kotlin/MockitoTest.kt
@@ -1,5 +1,6 @@
 import com.nhaarman.expect.expect
 import com.nhaarman.expect.expectErrorWithMessage
+import com.nhaarman.expect.fail
 import com.nhaarman.mockito_kotlin.*
 import org.junit.Test
 import org.mockito.exceptions.base.MockitoAssertionError
@@ -374,6 +375,80 @@ class MockitoTest {
 
         /* Then */
         expect(result).toBeTheSameAs(mock)
+    }
+
+    @Test
+    fun testMockStubbing_doThrow() {
+        /* Given */
+        val mock = mock<Methods> { mock ->
+            on { builderMethod() } doThrow IllegalArgumentException()
+        }
+
+        try {
+            /* When */
+            mock.builderMethod()
+            fail("No exception thrown")
+        } catch(e: IllegalArgumentException) {
+        }
+    }
+
+    @Test
+    fun testMockStubbing_doThrowClass() {
+        /* Given */
+        val mock = mock<Methods> { mock ->
+            on { builderMethod() } doThrow IllegalArgumentException::class
+        }
+
+        try {
+            /* When */
+            mock.builderMethod()
+            fail("No exception thrown")
+        } catch(e: IllegalArgumentException) {
+        }
+    }
+
+    @Test
+    fun testMockStubbing_doThrowVarargs() {
+        /* Given */
+        val mock = mock<Methods> { mock ->
+            on { builderMethod() }.doThrow(IllegalArgumentException(), UnsupportedOperationException())
+        }
+
+        try {
+            /* When */
+            mock.builderMethod()
+            fail("No exception thrown")
+        } catch(e: IllegalArgumentException) {
+        }
+
+        try {
+            /* When */
+            mock.builderMethod()
+            fail("No exception thrown")
+        } catch(e: UnsupportedOperationException) {
+        }
+    }
+
+    @Test
+    fun testMockStubbing_doThrowClassVarargs() {
+        /* Given */
+        val mock = mock<Methods> { mock ->
+            on { builderMethod() }.doThrow(IllegalArgumentException::class, UnsupportedOperationException::class)
+        }
+
+        try {
+            /* When */
+            mock.builderMethod()
+            fail("No exception thrown")
+        } catch(e: IllegalArgumentException) {
+        }
+
+        try {
+            /* When */
+            mock.builderMethod()
+            fail("No exception thrown")
+        } catch(e: UnsupportedOperationException) {
+        }
     }
 
     @Test

--- a/mockito-kotlin/src/testInlineMockito/kotlin/CreateInstanceOfImmutableTest.kt
+++ b/mockito-kotlin/src/testInlineMockito/kotlin/CreateInstanceOfImmutableTest.kt
@@ -1,0 +1,106 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 Ian J. De Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import com.nhaarman.expect.expect
+import com.nhaarman.mockito_kotlin.*
+import org.junit.Test
+import java.io.IOException
+import java.math.BigInteger
+
+class CreateInstanceOfImmutableTest {
+
+    class ClassToBeMocked {
+
+        fun doSomething(c: ClassToBeMocked) {
+        }
+
+        fun doSomethingElse(value: BigInteger): BigInteger {
+            return value.plus(BigInteger.ONE)
+        }
+    }
+
+    @Test
+    fun mockClosedClass() {
+        /* When */
+        val result = mock<ClassToBeMocked>()
+
+        /* Then */
+        expect(result).toNotBeNull()
+    }
+
+    @Test
+    fun anyClosedClass() {
+        /* Given */
+        val mock = mock<ClassToBeMocked>()
+
+        /* When */
+        mock.doSomething(mock)
+
+        /* Then */
+        verify(mock).doSomething(any())
+    }
+
+    @Test
+    fun mockClosedFunction_mockStubbing() {
+        /* Given */
+        val mock = mock<ClassToBeMocked> {
+            on { doSomethingElse(any()) } doReturn (BigInteger.ONE)
+        }
+
+        /* When */
+        val result = mock.doSomethingElse(BigInteger.TEN)
+
+        /* Then */
+        expect(result).toBe(BigInteger.ONE)
+    }
+
+    @Test
+    fun mockClosedFunction_whenever() {
+        /* Given */
+        val mock = mock<ClassToBeMocked>()
+        whenever(mock.doSomethingElse(any())).doReturn(BigInteger.ONE)
+
+        /* When */
+        val result = mock.doSomethingElse(BigInteger.TEN)
+
+        /* Then */
+        expect(result).toBe(BigInteger.ONE)
+    }
+
+    /** https://github.com/nhaarman/mockito-kotlin/issues/27 */
+    @Test
+    fun anyThrowableWithSingleThrowableConstructor() {
+        mock<Methods>().apply {
+            throwableClass(ThrowableClass(IOException()))
+            verify(this).throwableClass(any())
+        }
+    }
+
+    interface Methods {
+
+        fun throwableClass(t: ThrowableClass)
+    }
+
+    class ThrowableClass(cause: Throwable) : Throwable(cause)
+}

--- a/mockito-kotlin/src/testInlineMockito/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/mockito-kotlin/src/testInlineMockito/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
 - Updates Mockito to 2.2.1
 - Fixes issues:
  - #37 - ClassCastException when using `mock-maker-inline`
  - #75 - Attempting to verify mocked calls with a class that has a string array parameter in its constructor throws UnsupportedOperationException
 - Add `doThrow` infix methods to OngoingStubbing (#90)
 - Deprecates `capture { }` in favor of `argThat { }`, `argForWhich { }` or `check { }` (#91)