### PR TITLE
Release 0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Mockito-Kotlin
-[ ![Download](https://api.bintray.com/packages/nhaarman/maven/Mockito-Kotlin/images/download.svg) ](https://bintray.com/nhaarman/maven/Mockito-Kotlin/_latestVersion)
+[ ![Download](https://maven-badges.herokuapp.com/maven-central/com.nhaarman/mockito-kotlin/badge.svg) ](https://maven-badges.herokuapp.com/maven-central/com.nhaarman/mockito-kotlin)
 
 A small library that provides helper functions to work with [Mockito](https://github.com/mockito/mockito) in Kotlin.
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ A small library that provides helper functions to work with [Mockito](https://gi
 
 ## Install
 
-Mockito-Kotlin is available on JCenter.
-For Gradle users, add the following to your `build.gradle`:
+Mockito-Kotlin is available on Maven Central.
+For Gradle users, add the following to your `build.gradle`, replacing `x.x.x` with the latest version:
 
 ```groovy
 repositories {
-    jcenter()
+    mavenCentral()
 }
 dependencies {
     testCompile "com.nhaarman:mockito-kotlin:x.x.x"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,6 @@
+To publish a release:
+
+ - Tag the commit on master: `git tag -a x.x.x -m x.x.x && git push --tags`
+ - Execute the release process: `./gradlew clean test uploadArchives -PisRelease=true`
+ - Head to https://oss.sonatype.org/#stagingRepositories to close and release the deployment.
+ - Don't forget to publish the tag on Github with release notes :)

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,5 @@
 plugins {
-    id "com.jfrog.bintray" version "1.7.1"
     id 'com.github.ben-manes.versions' version '0.13.0'
 }
-apply plugin: 'maven'
-apply plugin: 'maven-publish'
 
 apply from: 'gradle/scripts/tagging.gradle'

--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -1,15 +1,18 @@
 apply plugin: 'kotlin'
 apply from: './publishing.gradle'
+apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
     ext.kotlin_version = '1.0.4'
 
     repositories {
         mavenCentral()
+        jcenter()
     }
 
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.9.9"
     }
 }
 
@@ -48,3 +51,15 @@ dependencies {
     testCompile "junit:junit:4.12"
     testCompile "com.nhaarman:expect.kt:0.6.0"
 }
+
+dokka {
+    outputFormat = 'html'
+    outputDirectory = "$buildDir/javadoc"
+
+    linkMapping {
+        dir = "src/main/kotlin"
+        url = "https://github.com/nhaarman/mockito-kotlin/tree/master/mockito-kotlin/src/main/kotlin"
+        suffix = "#L"
+    }
+}
+javadoc.dependsOn dokka

--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -45,7 +45,7 @@ test.dependsOn testInlineMockito
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "org.mockito:mockito-core:2.2.1"
+    compile "org.mockito:mockito-core:2.2.6"
 
     /* Tests */
     testCompile "junit:junit:4.12"

--- a/mockito-kotlin/publishing.gradle
+++ b/mockito-kotlin/publishing.gradle
@@ -1,37 +1,11 @@
-publishing {
-    publications {
-        MyPublication(MavenPublication) {
-            from components.java
-            artifact javadocJar
-            artifact sourcesJar
+apply plugin: 'maven'
+apply plugin: 'signing'
 
-            groupId 'com.nhaarman'
-            artifactId 'mockito-kotlin'
-            version rootProject.ext.versionName
-        }
-    }
-}
+group = 'com.nhaarman'
+version = rootProject.ext.versionName
+def sonatypeUsername = hasProperty('sonatype_username') ? sonatype_username : System.getenv('SONATYPE_USERNAME')
+def sonatypePassword = hasProperty('sonatype_password') ? sonatype_password : System.getenv('SONATYPE_PASSWORD')
 
-bintray {
-    user = hasProperty('bintray_user') ? bintray_user : System.getenv('BINTRAY_USER')
-    key = hasProperty('bintray_key') ? bintray_key : System.getenv('BINTRAY_KEY')
-    publications = ['MyPublication']
-
-    pkg {
-        repo = 'maven'
-        name = "Mockito-Kotlin"
-        desc = "Using Mockito with Kotlin"
-
-        licenses = ['MIT']
-        vcsUrl = 'https://github.com/bintray/gradle-bintray-plugin.git'
-
-        version {
-            name = rootProject.ext.versionName
-            desc = 'Using Mockito with Kotlin'
-            vcsTag = rootProject.ext.versionName
-        }
-    }
-}
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
@@ -41,4 +15,57 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 task sourcesJar(type: Jar) {
     from sourceSets.main.allSource
     classifier = 'sources'
+}
+
+artifacts {
+    archives jar
+
+    archives javadocJar
+    archives sourcesJar
+}
+
+signing {
+    sign configurations.archives
+}
+
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2") {
+                authentication(
+                        userName: sonatypeUsername,
+                        password: sonatypePassword
+                )
+            }
+
+            pom.project {
+                name 'Mockito-Kotlin'
+                packaging 'jar'
+                description 'Using Mockito with Kotlin.'
+                url 'https://github.com/nhaarman/mockito-kotlin'
+
+                scm {
+                    url 'scm:git@github.com:nhaarman/mockito-kotlin.git'
+                    connection 'scm:git@github.com:nhaarman/mockito-kotlin.git'
+                    developerConnection 'scm:git@github.com:nhaarman/mockito-kotlin.git'
+                }
+
+                licenses {
+                    license {
+                        name 'MIT'
+                        distribution 'repo'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id 'nhaarman'
+                        name 'Niek Haarman'
+                    }
+                }
+            }
+        }
+    }
 }

--- a/mockito-kotlin/publishing.gradle
+++ b/mockito-kotlin/publishing.gradle
@@ -9,7 +9,7 @@ def sonatypePassword = hasProperty('sonatype_password') ? sonatype_password : Sy
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
-    from 'build/docs/javadoc'
+    from 'build/javadoc'
 }
 
 task sourcesJar(type: Jar) {

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/ArgumentCaptor.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/ArgumentCaptor.kt
@@ -32,7 +32,7 @@ inline fun <reified T : Any> argumentCaptor(): KArgumentCaptor<T> = KArgumentCap
 
 inline fun <reified T : Any> capture(captor: ArgumentCaptor<T>): T = captor.capture() ?: createInstance<T>()
 
-@Deprecated("Use captor.capture() instead.", ReplaceWith("captor.capture()"))
+@Deprecated("Use captor.capture() instead.", ReplaceWith("captor.capture()"), DeprecationLevel.ERROR)
 inline fun <reified T : Any> capture(captor: KArgumentCaptor<T>): T = captor.capture()
 
 class KArgumentCaptor<out T : Any>(private val captor: ArgumentCaptor<T>, private val tClass: KClass<T>) {
@@ -51,7 +51,7 @@ class KArgumentCaptor<out T : Any>(private val captor: ArgumentCaptor<T>, privat
  * Instead, use [argumentCaptor] in the traditional way, or use one of
  * [argThat], [argForWhich] or [check].
  */
-@Deprecated("Use argumentCaptor() or argThat() instead.")
+@Deprecated("Use argumentCaptor() or argThat() instead.", ReplaceWith("check(consumer)"), DeprecationLevel.ERROR)
 inline fun <reified T : Any> capture(noinline consumer: (T) -> Unit): T {
     var times = 0
     return argThat { if (++times == 1) consumer.invoke(this); true }

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
@@ -130,14 +130,14 @@ fun verifyZeroInteractions(vararg mocks: Any) = Mockito.verifyZeroInteractions(*
 fun <T> whenever(methodCall: T): OngoingStubbing<T> = Mockito.`when`(methodCall)!!
 fun withSettings(): MockSettings = Mockito.withSettings()!!
 
-@Deprecated("Use any() instead.", ReplaceWith("any()"))
+@Deprecated("Use any() instead.", ReplaceWith("any()"), DeprecationLevel.ERROR)
 inline fun <reified T : Any> anyCollection(): Collection<T> = any()
 
-@Deprecated("Use any() instead.", ReplaceWith("any()"))
+@Deprecated("Use any() instead.", ReplaceWith("any()"), DeprecationLevel.ERROR)
 inline fun <reified T : Any> anyList(): List<T> = any()
 
-@Deprecated("Use any() instead.", ReplaceWith("any()"))
+@Deprecated("Use any() instead.", ReplaceWith("any()"), DeprecationLevel.ERROR)
 inline fun <reified T : Any> anySet(): Set<T> = any()
 
-@Deprecated("Use any() instead.", ReplaceWith("any()"))
+@Deprecated("Use any() instead.", ReplaceWith("any()"), DeprecationLevel.ERROR)
 inline fun <reified K : Any, reified V : Any> anyMap(): Map<K, V> = any()

--- a/mockito-kotlin/src/test/kotlin/MockitoTest.kt
+++ b/mockito-kotlin/src/test/kotlin/MockitoTest.kt
@@ -74,42 +74,6 @@ class MockitoTest {
     }
 
     @Test
-    fun anyCollectionOfClosed() {
-        mock<Methods>().apply {
-            closedCollection(listOf())
-            verify(this).closedCollection(any())
-            verify(this).closedCollection(anyCollection())
-        }
-    }
-
-    @Test
-    fun anyListOfClosed() {
-        mock<Methods>().apply {
-            closedList(listOf())
-            verify(this).closedList(any())
-            verify(this).closedList(anyList())
-        }
-    }
-
-    @Test
-    fun anyClosedStringMap() {
-        mock<Methods>().apply {
-            closedStringMap(mapOf())
-            verify(this).closedStringMap(any())
-            verify(this).closedStringMap(anyMap())
-        }
-    }
-
-    @Test
-    fun anyClosedSet() {
-        mock<Methods>().apply {
-            closedSet(setOf())
-            verify(this).closedSet(any())
-            verify(this).closedSet(anySet())
-        }
-    }
-
-    @Test
     fun anyStringVararg() {
         mock<Methods>().apply {
             closedVararg(Closed(), Closed())


### PR DESCRIPTION
 - First release on Maven Central
   - Add `mavenCentral()` to your repositories if necessary.
 - Updates Mockito to 2.2.6
 - Marks deprecated methods as `ERROR`, `ReplaceWith` suggestions are supplied.