### PR TITLE
Catch an NPE thrown by the Kotlin type checker in the Mockito library.

### DIFF
--- a/mockito-kotlin/src/test/kotlin/Classes.kt
+++ b/mockito-kotlin/src/test/kotlin/Classes.kt
@@ -54,7 +54,11 @@ interface Methods {
     fun nullableString(s: String?)
 
     fun stringResult(): String
-    fun builderMethod() : Methods
+    fun builderMethod(): Methods
+}
+
+interface GenericMethods<T> {
+    fun genericMethod(): T
 }
 
 class ThrowableClass(cause: Throwable) : Throwable(cause)

--- a/mockito-kotlin/src/test/kotlin/MockitoTest.kt
+++ b/mockito-kotlin/src/test/kotlin/MockitoTest.kt
@@ -436,4 +436,15 @@ class MockitoTest {
         expect(mock.stringResult()).toBe("a")
         expect(mock.stringResult()).toBe("b")
     }
+
+    @Test
+    fun doReturn_withGenericIntReturnType() {
+        /* Given */
+        val mock = mock<GenericMethods<Int>> {
+            on { genericMethod() } doReturn 2
+        }
+
+        /* Then */
+        expect(mock.genericMethod()).toBe(2)
+    }
 }


### PR DESCRIPTION
Fixes #104.
