### PR TITLE
Release 0.10.1

### DIFF
--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/CreateInstance.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/CreateInstance.kt
@@ -67,8 +67,8 @@ fun <T : Any> createInstance(kClass: KClass<T>): T {
     return MockitoKotlin.instanceCreator(kClass)?.invoke() as T? ?:
             when {
                 kClass.hasObjectInstance() -> kClass.objectInstance!!
-                kClass.isMockable() -> kClass.java.uncheckedMock()
                 kClass.isPrimitive() -> kClass.toDefaultPrimitiveValue()
+                kClass.isMockable() -> kClass.java.uncheckedMock()
                 kClass.isEnum() -> kClass.java.enumConstants.first()
                 kClass.isArray() -> kClass.toArrayInstance()
                 kClass.isClassObject() -> kClass.toClassObject()

--- a/mockito-kotlin/src/test/kotlin/Classes.kt
+++ b/mockito-kotlin/src/test/kotlin/Classes.kt
@@ -54,7 +54,11 @@ interface Methods {
     fun nullableString(s: String?)
 
     fun stringResult(): String
-    fun builderMethod() : Methods
+    fun builderMethod(): Methods
+}
+
+interface GenericMethods<T> {
+    fun genericMethod(): T
 }
 
 class ThrowableClass(cause: Throwable) : Throwable(cause)

--- a/mockito-kotlin/src/test/kotlin/MockitoTest.kt
+++ b/mockito-kotlin/src/test/kotlin/MockitoTest.kt
@@ -436,4 +436,15 @@ class MockitoTest {
         expect(mock.stringResult()).toBe("a")
         expect(mock.stringResult()).toBe("b")
     }
+
+    @Test
+    fun doReturn_withGenericIntReturnType() {
+        /* Given */
+        val mock = mock<GenericMethods<Int>> {
+            on { genericMethod() } doReturn 2
+        }
+
+        /* Then */
+        expect(mock.genericMethod()).toBe(2)
+    }
 }

--- a/mockito-kotlin/src/testInlineMockito/kotlin/CreateInstanceInlineTest.kt
+++ b/mockito-kotlin/src/testInlineMockito/kotlin/CreateInstanceInlineTest.kt
@@ -28,7 +28,7 @@ import org.junit.Test
 import java.io.IOException
 import java.math.BigInteger
 
-class CreateInstanceOfImmutableTest {
+class CreateInstanceInlineTest {
 
     class ClassToBeMocked {
 
@@ -95,6 +95,24 @@ class CreateInstanceOfImmutableTest {
             throwableClass(ThrowableClass(IOException()))
             verify(this).throwableClass(any())
         }
+    }
+
+    @Test
+    fun createPrimitiveInstance() {
+        /* When */
+        val i = createInstance<Int>()
+
+        /* Then */
+        expect(i).toBe(0)
+    }
+    
+    @Test
+    fun createStringInstance() {
+        /* When */
+        val s = createInstance<String>()
+
+        /* Then */
+        expect(s).toBe("")
     }
 
     interface Methods {


### PR DESCRIPTION
 - Fixes a NPE thrown when trying to mock a generic type (#104)
 - Doesn't try to mock primitive and wrapper types anymore (#106)