### PR TITLE
Accept nullable return types when stubbing

### DIFF
--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
@@ -94,7 +94,7 @@ inline fun <reified T : Any> mock(stubbing: KStubbing<T>.(T) -> Unit): T {
 class KStubbing<out T>(private val mock: T) {
     fun <R> on(methodCall: R) = Mockito.`when`(methodCall)
 
-    fun <R : Any> on(methodCall: T.() -> R, c: KClass<R>): OngoingStubbing<R> {
+    fun <R : Any> onGeneric(methodCall: T.() -> R, c: KClass<R>): OngoingStubbing<R> {
         val r = try {
             mock.methodCall()
         } catch(e: NullPointerException) {
@@ -108,8 +108,16 @@ class KStubbing<out T>(private val mock: T) {
         return Mockito.`when`(r)
     }
 
-    inline fun <reified R : Any> on(noinline methodCall: T.() -> R): OngoingStubbing<R> {
-        return on(methodCall, R::class)
+    inline fun <reified R : Any> onGeneric(noinline methodCall: T.() -> R): OngoingStubbing<R> {
+        return onGeneric(methodCall, R::class)
+    }
+
+    fun <R> on(methodCall: T.() -> R): OngoingStubbing<R> {
+        return try {
+            Mockito.`when`(mock.methodCall())
+        } catch(e: NullPointerException) {
+            throw MockitoKotlinException("NullPointerException thrown when stubbing. If you are trying to stub a generic method, try `onGeneric` instead.", e)
+        }
     }
 }
 

--- a/mockito-kotlin/src/test/kotlin/Classes.kt
+++ b/mockito-kotlin/src/test/kotlin/Classes.kt
@@ -54,6 +54,7 @@ interface Methods {
     fun nullableString(s: String?)
 
     fun stringResult(): String
+    fun nullableStringResult(): String?
     fun builderMethod(): Methods
 }
 

--- a/mockito-kotlin/src/test/kotlin/MockitoTest.kt
+++ b/mockito-kotlin/src/test/kotlin/MockitoTest.kt
@@ -352,6 +352,20 @@ class MockitoTest {
     }
 
     @Test
+    fun testMockStubbing_nullable() {
+        /* Given */
+        val mock = mock<Methods> {
+            on { nullableStringResult() } doReturn "Test"
+        }
+
+        /* When */
+        val result = mock.nullableStringResult()
+
+        /* Then */
+        expect(result).toBe("Test")
+    }
+
+    @Test
     fun testMockStubbing_doThrow() {
         /* Given */
         val mock = mock<Methods> { mock ->
@@ -438,10 +452,22 @@ class MockitoTest {
     }
 
     @Test
-    fun doReturn_withGenericIntReturnType() {
+    fun doReturn_withGenericIntReturnType_on() {
+        /* Expect */
+        expectErrorWithMessage("onGeneric") on {
+
+            /* When */
+            mock<GenericMethods<Int>> {
+                on { genericMethod() } doReturn 2
+            }
+        }
+    }
+
+    @Test
+    fun doReturn_withGenericIntReturnType_onGeneric() {
         /* Given */
         val mock = mock<GenericMethods<Int>> {
-            on { genericMethod() } doReturn 2
+            onGeneric { genericMethod() } doReturn 2
         }
 
         /* Then */


### PR DESCRIPTION
For easier usage with nullable types. 