### PR TITLE
Release 0.12.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,13 @@ language: java
 matrix:
   include:
   - jdk: oraclejdk7
-    env: TERM=dumb MOCK_MAKER=mock-maker-inline KOTLIN_VERSION=1.0.5
+    env: TERM=dumb MOCK_MAKER=mock-maker-inline KOTLIN_VERSION=1.0.5-2
   - jdk: oraclejdk7
     env: TERM=dumb MOCK_MAKER=mock-maker-inline KOTLIN_VERSION=1.1-M02
   - jdk: oraclejdk8
-    env: TERM=dumb MOCK_MAKER=mock-maker-inline KOTLIN_VERSION=1.0.5
+    env: TERM=dumb KOTLIN_VERSION=1.0.5-2
   - jdk: oraclejdk8
-    env: TERM=dumb MOCK_MAKER=mock-maker-inline KOTLIN_VERSION=1.1-M02
+    env: TERM=dumb KOTLIN_VERSION=1.1-M02
 
 
 env:

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,3 @@
 #
 
 isRelease = false
-publishToLocal = false

--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -26,7 +26,7 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "org.mockito:mockito-core:2.2.15"
+    compile "org.mockito:mockito-core:2.2.17"
 
     /* Tests */
     testCompile "junit:junit:4.12"

--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -3,7 +3,7 @@ apply from: './publishing.gradle'
 apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
-    ext.kotlin_version = System.getenv("KOTLIN_VERSION") ?: '1.0.5'
+    ext.kotlin_version = System.getenv("KOTLIN_VERSION") ?: '1.0.5-2'
 
     repositories {
         mavenCentral()

--- a/mockito-kotlin/publishing.gradle
+++ b/mockito-kotlin/publishing.gradle
@@ -40,8 +40,6 @@ uploadArchives {
                 )
             }
 
-            if (publishToLocal) repository(url: mavenLocal().url)
-
             pom.project {
                 name 'Mockito-Kotlin'
                 packaging 'jar'

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
@@ -76,6 +76,7 @@ fun doThrow(vararg toBeThrown: Throwable): Stubber = Mockito.doThrow(*toBeThrown
 fun <T> eq(value: T): T = Mockito.eq(value) ?: value
 fun ignoreStubs(vararg mocks: Any): Array<out Any> = Mockito.ignoreStubs(*mocks)!!
 fun inOrder(vararg mocks: Any): InOrder = Mockito.inOrder(*mocks)!!
+fun inOrder(vararg mocks: Any, evaluation: InOrder.() -> Unit) = Mockito.inOrder(*mocks).evaluation()
 
 inline fun <reified T : Any> isA(): T? = Mockito.isA(T::class.java)
 fun <T : Any> isNotNull(): T? = Mockito.isNotNull()

--- a/mockito-kotlin/src/test/kotlin/test/MockitoTest.kt
+++ b/mockito-kotlin/src/test/kotlin/test/MockitoTest.kt
@@ -1,4 +1,5 @@
 package test
+
 import com.nhaarman.expect.expect
 import com.nhaarman.expect.expectErrorWithMessage
 import com.nhaarman.expect.fail
@@ -174,6 +175,23 @@ class MockitoTest : TestBase() {
             string("")
 
             inOrder(this).verify(this, calls(2)).string(any())
+        }
+    }
+
+    @Test
+    fun testInOrderWithLambda() {
+        /* Given */
+        val a = mock<() -> Unit>()
+        val b = mock<() -> Unit>()
+
+        /* When */
+        b()
+        a()
+
+        /* Then */
+        inOrder(a, b) {
+            verify(b).invoke()
+            verify(a).invoke()
         }
     }
 


### PR DESCRIPTION
 - Updates Kotlin to 1.0.5-2
 - Updates Mockito to 2.2.17
 - `inOrder` accepts a lambda for easy verification (#122)