### PR TITLE
Release 0.12.2

### DIFF
--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -26,7 +26,7 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "org.mockito:mockito-core:2.2.17"
+    compile "org.mockito:mockito-core:2.2.22"
 
     /* Tests */
     testCompile "junit:junit:4.12"

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
@@ -78,7 +78,7 @@ fun ignoreStubs(vararg mocks: Any): Array<out Any> = Mockito.ignoreStubs(*mocks)
 fun inOrder(vararg mocks: Any): InOrder = Mockito.inOrder(*mocks)!!
 fun inOrder(vararg mocks: Any, evaluation: InOrder.() -> Unit) = Mockito.inOrder(*mocks).evaluation()
 
-inline fun <reified T : Any> isA(): T? = Mockito.isA(T::class.java)
+inline fun <reified T : Any> isA(): T = Mockito.isA(T::class.java) ?: createInstance<T>()
 fun <T : Any> isNotNull(): T? = Mockito.isNotNull()
 fun <T : Any> isNull(): T? = Mockito.isNull()
 

--- a/mockito-kotlin/src/test/kotlin/test/MockitoTest.kt
+++ b/mockito-kotlin/src/test/kotlin/test/MockitoTest.kt
@@ -492,4 +492,19 @@ class MockitoTest : TestBase() {
         /* Then */
         expect(mock.genericMethod()).toBe(2)
     }
+
+    @Test
+    fun isA_withNonNullableString() {
+        mock<Methods>().apply {
+            string("")
+            verify(this).string(isA<String>())
+        }
+    }
+    @Test
+    fun isA_withNullableString() {
+        mock<Methods>().apply {
+            nullableString("")
+            verify(this).nullableString(isA<String>())
+        }
+    }
 }


### PR DESCRIPTION
 - `isA()` returns a non-null instance