### PR TITLE
Handle `null` in argument matchers.

### DIFF
--- a/mockito-kotlin/src/test/kotlin/test/Classes.kt
+++ b/mockito-kotlin/src/test/kotlin/test/Classes.kt
@@ -1,4 +1,6 @@
-package test/*
+package test
+
+/*
 * The MIT License
 *
 * Copyright (c) 2016 Niek Haarman
@@ -55,6 +57,7 @@ interface Methods {
     fun nullableString(s: String?)
 
     fun stringResult(): String
+    fun stringResult(s: String): String
     fun nullableStringResult(): String?
     fun builderMethod(): Methods
 }

--- a/mockito-kotlin/src/test/kotlin/test/MockitoTest.kt
+++ b/mockito-kotlin/src/test/kotlin/test/MockitoTest.kt
@@ -139,6 +139,17 @@ class MockitoTest : TestBase() {
     }
 
     @Test
+    fun checkWithNullArgument_throwsError() {
+        mock<Methods>().apply {
+            nullableString(null)
+
+            expectErrorWithMessage("null").on {
+                verify(this).nullableString(check {})
+            }
+        }
+    }
+
+    @Test
     fun atLeastXInvocations() {
         mock<Methods>().apply {
             string("")
@@ -459,6 +470,30 @@ class MockitoTest : TestBase() {
     }
 
     @Test
+    fun stubbingTwiceWithArgumentMatchers() {
+        /* When */
+        val mock = mock<Methods> {
+            on { stringResult(argThat { this == "A" }) } doReturn "A"
+            on { stringResult(argThat { this == "B" }) } doReturn "B"
+        }
+
+        /* Then */
+        expect(mock.stringResult("A")).toBe("A")
+        expect(mock.stringResult("B")).toBe("B")
+    }
+
+    @Test
+    fun stubbingTwiceWithCheckArgumentMatchers_throwsException() {
+        /* Expect */
+        expectErrorWithMessage("null").on {
+            mock<Methods> {
+                on { stringResult(check { }) } doReturn "A"
+                on { stringResult(check { }) } doReturn "B"
+            }
+        }
+    }
+
+    @Test
     fun doReturn_withSingleItemList() {
         /* Given */
         val mock = mock<Open> {
@@ -500,6 +535,7 @@ class MockitoTest : TestBase() {
             verify(this).string(isA<String>())
         }
     }
+
     @Test
     fun isA_withNullableString() {
         mock<Methods>().apply {


### PR DESCRIPTION
When stubbing with argument matchers, the following
scenario would cause a NullPointerException:

```kotlin
whenever(mock.doSomething(argThat { })).thenReturn("")
whenever(mock.doSomething(argThat { })).thenReturn("")
```

The second `argThat` invocation returns a `null` value,
which gets propagated into the function passed to the
first `argThat` invocation.

This commit filters `null` values to always evaluate to
`false` when provided to an argument matcher.

Fixes #133.
Fixes #134 by throwing a descriptive error.