### PR TITLE
Release 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,13 @@ language: java
 matrix:
   include:
   - jdk: oraclejdk7
-    env: TERM=dumb MOCK_MAKER=mock-maker-inline KOTLIN_VERSION=1.0.5-3
+    env: TERM=dumb MOCK_MAKER=mock-maker-inline KOTLIN_VERSION=1.0.6
   - jdk: oraclejdk7
-    env: TERM=dumb MOCK_MAKER=mock-maker-inline KOTLIN_VERSION=1.1-M03
+    env: TERM=dumb MOCK_MAKER=mock-maker-inline KOTLIN_VERSION=1.1-M04
   - jdk: oraclejdk8
-    env: TERM=dumb KOTLIN_VERSION=1.0.5-3
+    env: TERM=dumb KOTLIN_VERSION=1.0.6
   - jdk: oraclejdk8
-    env: TERM=dumb KOTLIN_VERSION=1.1-M03
+    env: TERM=dumb KOTLIN_VERSION=1.1-M04
 
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ language: java
 matrix:
   include:
   - jdk: oraclejdk7
-    env: TERM=dumb MOCK_MAKER=mock-maker-inline KOTLIN_VERSION=1.0.5-2
+    env: TERM=dumb MOCK_MAKER=mock-maker-inline KOTLIN_VERSION=1.0.5-3
   - jdk: oraclejdk7
     env: TERM=dumb MOCK_MAKER=mock-maker-inline KOTLIN_VERSION=1.1-M03
   - jdk: oraclejdk8
-    env: TERM=dumb KOTLIN_VERSION=1.0.5-2
+    env: TERM=dumb KOTLIN_VERSION=1.0.5-3
   - jdk: oraclejdk8
     env: TERM=dumb KOTLIN_VERSION=1.1-M03
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.2.1-all.zip

--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -3,7 +3,7 @@ apply from: './publishing.gradle'
 apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
-    ext.kotlin_version = System.getenv("KOTLIN_VERSION") ?: '1.0.5-3'
+    ext.kotlin_version = System.getenv("KOTLIN_VERSION") ?: '1.0.6'
 
     repositories {
         mavenCentral()

--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -3,7 +3,7 @@ apply from: './publishing.gradle'
 apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
-    ext.kotlin_version = System.getenv("KOTLIN_VERSION") ?: '1.0.5-2'
+    ext.kotlin_version = System.getenv("KOTLIN_VERSION") ?: '1.0.5-3'
 
     repositories {
         mavenCentral()
@@ -13,7 +13,7 @@ buildscript {
 
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.9.10"
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.9.11"
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3"
         classpath "com.github.dcendents:android-maven-gradle-plugin:1.5"
     }
@@ -28,7 +28,7 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "org.mockito:mockito-core:2.2.28"
+    compile "org.mockito:mockito-core:2.3.9"
 
     /* Tests */
     testCompile "junit:junit:4.12"

--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -28,7 +28,7 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "org.mockito:mockito-core:2.3.9"
+    compile "org.mockito:mockito-core:2.4.5"
 
     /* Tests */
     testCompile "junit:junit:4.12"

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/BDDMockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/BDDMockito.kt
@@ -1,0 +1,13 @@
+package com.nhaarman.mockito_kotlin
+
+import org.mockito.BDDMockito
+
+fun <T> given(methodCall: T): BDDMockito.BDDMyOngoingStubbing<T> = BDDMockito.given(methodCall)
+fun <T> given(methodCall: () -> T) = given(methodCall())
+
+fun <T> then(mock: T): BDDMockito.Then<T> = BDDMockito.then(mock)
+
+infix fun <T> BDDMockito.BDDMyOngoingStubbing<T>.willAnswer(value: () -> T): BDDMockito.BDDMyOngoingStubbing<T> = willAnswer { value() }
+infix fun <T> BDDMockito.BDDMyOngoingStubbing<T>.willReturn(value: () -> T): BDDMockito.BDDMyOngoingStubbing<T> = willReturn(value())
+infix fun <T> BDDMockito.BDDMyOngoingStubbing<T>.willThrow(value: () -> Throwable): BDDMockito.BDDMyOngoingStubbing<T> = willThrow(value())
+

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
@@ -69,6 +69,14 @@ inline fun <reified T : Any> argThat(noinline predicate: T.() -> Boolean) = Mock
 inline fun <reified T : Any> argForWhich(noinline predicate: T.() -> Boolean) = argThat(predicate)
 
 /**
+ * Creates a custom argument matcher.
+ * `null` values will never evaluate to `true`.
+ *
+ * @param predicate A function that returns `true` when given [T] matches the predicate.
+ */
+inline fun <reified T: Any> argWhere(noinline predicate: (T) -> Boolean) = argThat(predicate)
+
+/**
  * For usage with verification only.
  *
  * For example:

--- a/mockito-kotlin/src/test/kotlin/test/BDDMockitoTest.kt
+++ b/mockito-kotlin/src/test/kotlin/test/BDDMockitoTest.kt
@@ -1,0 +1,103 @@
+package test
+
+import com.nhaarman.expect.expect
+import com.nhaarman.mockito_kotlin.*
+import org.junit.Test
+
+class BDDMockitoTest {
+
+    @Test
+    fun given_willReturn_properlyStubs() {
+        /* Given */
+        val mock = mock<Methods>()
+
+        /* When */
+        given(mock.stringResult()).willReturn("Test")
+
+        /* Then */
+        expect(mock.stringResult()).toBe("Test")
+    }
+
+    @Test
+    fun givenLambda_willReturn_properlyStubs() {
+        /* Given */
+        val mock = mock<Methods>()
+
+        /* When */
+        given { mock.stringResult() }.willReturn("Test")
+
+        /* Then */
+        expect(mock.stringResult()).toBe("Test")
+    }
+
+    @Test
+    fun given_willReturnLambda_properlyStubs() {
+        /* Given */
+        val mock = mock<Methods>()
+
+        /* When */
+        given(mock.stringResult()).willReturn { "Test" }
+
+        /* Then */
+        expect(mock.stringResult()).toBe("Test")
+    }
+
+    @Test
+    fun givenLambda_willReturnLambda_properlyStubs() {
+        /* Given */
+        val mock = mock<Methods>()
+
+        /* When */
+        given { mock.stringResult() } willReturn { "Test" }
+
+        /* Then */
+        expect(mock.stringResult()).toBe("Test")
+    }
+
+    @Test
+    fun given_willAnswer_properlyStubs() {
+        /* Given */
+        val mock = mock<Methods>()
+
+        /* When */
+        given(mock.stringResult()).willAnswer { "Test" }
+
+        /* Then */
+        expect(mock.stringResult()).toBe("Test")
+    }
+
+    @Test
+    fun given_willAnswerInfix_properlyStubs() {
+        /* Given */
+        val mock = mock<Methods>()
+
+        /* When */
+        given(mock.stringResult()) willAnswer { "Test" }
+
+        /* Then */
+        expect(mock.stringResult()).toBe("Test")
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun given_willThrowInfix_properlyStubs() {
+        /* Given */
+        val mock = mock<Methods>()
+
+        /* When */
+        given(mock.stringResult()) willThrow { IllegalStateException() }
+        mock.stringResult()
+    }
+
+    @Test
+    fun then() {
+        /* Given */
+        val mock = mock<Methods>()
+        whenever(mock.stringResult()).thenReturn("Test")
+
+        /* When */
+        mock.stringResult()
+
+        /* Then */
+        then(mock).should().stringResult()
+    }
+}

--- a/mockito-kotlin/src/test/kotlin/test/MockitoTest.kt
+++ b/mockito-kotlin/src/test/kotlin/test/MockitoTest.kt
@@ -129,6 +129,16 @@ class MockitoTest : TestBase() {
     }
 
     @Test
+    fun listArgWhere() {
+        mock<Methods>().apply {
+            closedList(listOf(Closed(), Closed()))
+            verify(this).closedList(argWhere {
+                it.size == 2
+            })
+        }
+    }
+
+    @Test
     fun listArgCheck() {
         mock<Methods>().apply {
             closedList(listOf(Closed(), Closed()))

--- a/mockito-kotlin/src/test/kotlin/test/inline/UsingMockMakerInlineTest.kt
+++ b/mockito-kotlin/src/test/kotlin/test/inline/UsingMockMakerInlineTest.kt
@@ -23,7 +23,6 @@
  */
 
 import com.nhaarman.expect.expect
-import com.nhaarman.expect.expectErrorWithMessage
 import com.nhaarman.mockito_kotlin.*
 import com.nhaarman.mockito_kotlin.createinstance.InstanceCreator
 import com.nhaarman.mockito_kotlin.createinstance.mockMakerInlineEnabled
@@ -129,13 +128,12 @@ class UsingMockMakerInlineTest {
     }
 
     @Test
-    fun sealedClass_fails() {
-        /* Expect */
-        expectErrorWithMessage("Could not create") on {
+    fun sealedMemberClass() {
+        /* When */
+        val result = createInstance<MySealedClass>()
 
-            /* When */
-            createInstance<MySealedClass>()
-        }
+        /* Then */
+        expect(result).toNotBeNull()
     }
 
     @Test

--- a/tmp.txt
+++ b/tmp.txt
@@ -1,0 +1,181 @@
+a1ea33b Update Dokka to 0.9.11
+e3344f4 Update Gradle wrapper to 3.2.1
+3c714eb Update Kotlin to 1.0.5-3
+8118f1a Update Mockito to 2.3.9
+327d431 Merge pull request #137 from nhaarman/release-1.0.1
+8c9e5d7 Merge branch 'master' into dev
+e07e419 Update PULL_REQUEST_TEMPLATE.md
+263344f Merge pull request #135 from nhaarman/handle-null-in-argumentmatcher
+b77d969 Handle `null` in argument matchers.
+543238f Merge pull request #131 from nhaarman/release-1.0.0
+ed6d30d Update tagging script
+af1940c Update Mockito to 2.2.28
+0ba47f4 Update dokka plugin
+04cd24d Merge pull request #130 from nhaarman/release-1.0.0-RC1
+5418cff Update README.md
+559ffc5 Remove deprecated methods
+dc4ab0a Update publishing
+a734cde Test with Kotlin 1.1-M03
+7fb4bd9 Merge pull request #127 from nhaarman/release-0.12.2
+05a65ec Update Mockito to 2.2.22
+62f3170 Merge branch 'ghostbuster91-FeatureRequest_isAclassShouldReturnInstance' into dev
+acde82f Change isA method to return instance of T
+72279be Merge pull request #123 from nhaarman/release-0.12.1
+c974db0 Update Mockito to 2.2.17
+e6f6d2c Update Kotlin to 1.0.5-2
+b665264 Merge pull request #122 from nhaarman/inorder-lambda
+59bf311 Add a lambda to inOrder() for easier verification
+b50831b Fix release build config
+ebc6147 Merge pull request #121 from nhaarman/release-0.12.0
+66d8249 Also test with Kotlin 1.1
+cdc34a0 Merge pull request #120 from nhaarman/cast-null
+18ed580 Use `null as T` to create instances
+ae1d863 Merge pull request #119 from nhaarman/clean-tests
+ab1eb0d Use same test source for inline tests
+2b31ed7 Merge branch 'master' into dev
+57d0d8b Merge pull request #118 from nhaarman/improve-argumentcaptor
+81a0996 Add value shortcuts to ArgumentCaptor
+37f1717 Merge pull request #117 from nhaarman/nullable-eq
+1eead3e Return passed value instead of trying to create an instance
+a831657 Update Mockito to 2.2.15
+5f12032 Merge pull request #113 from rongi/patch-1
+e7ed7cb Update to Kotlin 1.0.5
+27c6bf6 Merge pull request #111 from nhaarman/release-0.11.0
+771f761 Merge pull request #110 from nhaarman/graciously_fail
+c8fecf0 Try to use constructor when mocking fails
+fa27978 Merge pull request #109 from nhaarman/nullable-mockstubbing
+f353562 Accept nullable return types when stubbing
+50a1b91 Merge pull request #108 from nhaarman/release-0.10.1
+c3f7e68 Merge pull request #107 from nhaarman/create-primitive-instance
+0615231 Don't try to mock primitive/wrapper instances
+494e7ca Merge pull request #105 from nhaarman/fix-generic-returntype-npe
+113d9e9 Catch an NPE thrown by the Kotlin type checker in the Mockito library.
+3b5c40a Merge pull request #102 from nhaarman/release-0.10.0
+6af0904 Update Mockito to 2.2.9
+287065a Merge pull request #101 from nhaarman/skip-optional-parameters
+42cee20 Don't count optional parameters when trying to find an easy constructor
+e43ccea Merge pull request #100 from nhaarman/nullable-argumentcaptor
+086d482 Add `nullableArgumentCaptor` to be able to work with lists of nullables
+7b6c5b7 Merge branch 'desilvai-dev' into dev
+395e578 Fixed infinite loop caused by 'copy constructors' invoked by createInstance.  The fix is to skip all constructors that take in parameters with same type as the object we are trying to build.
+24108bd Merge pull request #98 from nhaarman/release-0.9.0
+6126454 Update version badge
+5a31910 Merge pull request #97 from nhaarman/deprecation-levels
+63826bf Upgrade deprecation levels to ERROR
+3db9e21 Update Mockito to 2.2.6
+5884adc Merge pull request #96 from nhaarman/dokka
+fb74552 Use dokka do generate docs
+f165976 Merge pull request #95 from nhaarman/publish-to-maven-central
+8e083ad Publish to Maven Central instead of Bintray
+5878bbe Merge pull request #93 from nhaarman/release-0.8.0
+d556691 Update Mockito to 2.2.1
+6ee75f7 Merge pull request #92 from nhaarman/create-array-instance
+0b43d0b Use the java class' name to create an array instance
+cd16b04 Merge pull request #91 from nhaarman/improve-captors
+80dbefd Improve argument captors
+fd98501 Merge pull request #90 from nhaarman/ongoingstubbing-dothrow
+94b3c65 Added doThrow methods to OngoingStubbing
+85bb5e4 Merge branch 'desilvai-dev' into dev
+6965414 Fix compatibility with mock-maker-inline for mocking final classes
+ea6e64c Merge pull request #85 from nhaarman/release-0.7.0
+36e3dd5 Merge pull request #84 from nhaarman/fix-createinstance-from-lambda
+1d65fc0 Strip methods from file identifiers.
+1025568 Merge pull request #83 from nhaarman/stubbing-mock-reference
+0c3e137 Provide mock instance to stubbing method in mock()
+3f73e27 Merge pull request #82 from nhaarman/mockito-rc2
+e549d8d Update Mockito dependency to 2.1.0
+0886485 Update Mockito dependency to RC2
+2d724bc Merge pull request #74 from viniciussoares/dev
+f2ed004 Upgrade Kotlin to 1.0.4.
+9c4234e Merge pull request #73 from nhaarman/release-0.6.2
+cf06555 Merge pull request #72 from nhaarman/any-or-null
+9351840 Include `anyOrNull()`
+3d64888 Merge pull request #71 from jpshelley/mockito-2.1.0-RC.1
+6862ea5 update to RC.1
+4c09ebc Merge branch 'master' into dev
+f18d86e Merge pull request #70 from nhaarman/release-0.6.1
+650e293 Update README.md
+f291e71 Merge pull request #69 from nhaarman/argforwhich
+9a3b7de Introduce argForWhich() as an alias for argThat()
+8d53bad Merge pull request #68 from nhaarman/fix-anyarrayofnullables
+9507a20 Make anyArray() accept nullable types.
+7dcebc9 Stop. Sending me. Emails.
+c029a13 Merge pull request #67 from nhaarman/deprecate-deprecated-methods
+400b1cc Deprecate methods that are deprecated in Mockito.
+c06d37f Merge pull request #64 from nhaarman/fix-simplest-constructor
+18be968 Improve `easiestConstructor()` to sort by parameters size.
+855c14b Update gradle wrapper to 3.0
+58013d8 Update dependencies
+6110a90 Update Mockito version to 2.1.0-beta.125
+6cf8557 Update README.md
+d07a2c9 Merge pull request #59 from nhaarman/release-0.6.0
+2a2ed98 Merge pull request #58 from nhaarman/mock-stubbing
+ecfaf58 Add infix modifiers to doReturn methods
+2d4eef9 Accept a stubbing lambda in mock()
+84fb7e0 Merge branch 'master' into dev
+49d59a6 Merge pull request #55 from sghill/mockito-2.0.99-beta
+2f94f52 Upgrade Mockito to 2.0.99-beta
+a6f8604 Merge pull request #53 from nhaarman/release-0.5.2
+51385ca Added an example to the Readme on Argument Captors.
+6a521ea Make `doReturn` accept null values.
+c3e6182 Specify explicit return types for Mockito calls.
+6867394 Merge pull request #50 from Zoltu/patch-1
+25fb19c Upgrade Kotlin version to 1.0.3.
+e1de1f6 Makes `mock` return non-null types.
+bb4ac76 Merge pull request #43 from nhaarman/release-0.5.1
+8e6ab15 Update gradle wrapper version
+c400381 Merge pull request #42 from hamen/master
+c44c15a Update Kotlin version
+62cd94f Merge pull request #38 from nhaarman/release-0.5.0
+aa49bde Merge pull request #23 from nhaarman/instance-creators
+f765a31 Use instance creators only from single test file.
+17dadf9 Update README.md
+cddcf7f Introduce instance creators.
+4cbd876 Merge pull request #36 from nhaarman/release-0.4.1
+abfc083 Update dependencies
+772d0d9 Merge pull request #33 from nhaarman/release-0.4.0
+1322b92 Update dependencies
+55e9a3c Merge pull request #30 from nhaarman/release-0.3.1
+df0c3f6 Remove Travis-CI cache
+d4e73a9 Merge pull request #29 from nhaarman/uncheckedmock-interceptor
+c8d9f68 Unset the MockitoInterceptor for unchecked mocks.
+129f9e6 Merge pull request #28 from nhaarman/create-class-objects
+ae4ab17 Account for Class<T> when creating instances.
+a013a48 Merge pull request #19 from nhaarman/avoid-array-parameters
+ea0263d Avoid constructors with an array as a parameter.
+48fc1aa Merge pull request #16 from nhaarman/release-0.3.0
+fc95068 Merge branch 'dev' of https://github.com/codeborne/mockito-kotlin into codeborne-dev
+5105493 Include more static Mockito methods
+9238c4c add simpler capture() method with lambda
+ce93783 Merge pull request #12 from codeborne/master
+66e3be5 add simplified ArgumentCaptor support
+1262c19 add deep stubs test
+f6f142a add spy stubbing tests
+0efd093 Added PR template
+624b7c4 Merge pull request #10 from ViFork/master
+334d471 add missing imports
+76be5d0 add more missing Mockito methods, especially to be used with spies
+40bf7c6 changed kotlin version to 1.0.0
+7cafd23 Merge pull request #7 from nhaarman/release-0.2.0
+8b93c66 Update Kotlin to rc-1036
+8488479 Merge pull request #6 from nhaarman/release-0.1.6
+1d9a588 Use smallest constructor
+37ded6f Merge pull request #5 from nhaarman/release-0.1.5
+8157be6 Support Boolean
+0665c25 Merge pull request #4 from nhaarman/release-0.1.4
+a873fa7 Support private classes
+0cc78ba Merge pull request #3 from nhaarman/release-0.1.3
+65d6a5f Support object instances
+c4bde0f Merge pull request #2 from nhaarman/release-0.1.2
+9856798 Proper license
+9f1df2d Make sure 'eq' does not return null
+90f6598 Merge branch 'master' into dev
+b40c9ae Update README.md
+ad964f7 Update README.md
+92bb350 Cache Travis dependencies
+886cad6 Proper version names
+139d47c Proper version names
+78505b7 Merge pull request #1 from nhaarman/release-0.1.1
+b5a4e87 Support enums
+b113029 Upload to Bintray
+2f9603a Initial commit


### PR DESCRIPTION
 - Updates Mockito to 2.4.5
 - Updates Kotlin to 1.0.6
 - Adds `argWhere` ( #141 )
 - Adds BDDMockito functions ( #142 )