### PR TITLE
Settings api

### DIFF
--- a/mockito-kotlin/src/test/kotlin/test/Classes.kt
+++ b/mockito-kotlin/src/test/kotlin/test/Classes.kt
@@ -60,6 +60,17 @@ interface Methods {
     fun stringResult(s: String): String
     fun nullableStringResult(): String?
     fun builderMethod(): Methods
+
+    fun nonDefaultReturnType(): ExtraInterface
+}
+
+interface ExtraInterface
+
+abstract class ThrowingConstructor {
+
+    constructor() {
+        error("Error in constructor")
+    }
 }
 
 interface GenericMethods<T> {

--- a/mockito-kotlin/src/test/kotlin/test/MockitoTest.kt
+++ b/mockito-kotlin/src/test/kotlin/test/MockitoTest.kt
@@ -6,6 +6,7 @@ import com.nhaarman.expect.fail
 import com.nhaarman.mockito_kotlin.*
 import org.junit.Test
 import org.mockito.Mockito
+import org.mockito.Mockito.RETURNS_MOCKS
 import org.mockito.exceptions.base.MockitoAssertionError
 import org.mockito.exceptions.verification.WantedButNotInvoked
 import org.mockito.listeners.InvocationListener
@@ -40,6 +41,7 @@ import java.io.Serializable
  * THE SOFTWARE.
  */
 
+@Suppress("DEPRECATION")
 class MockitoTest : TestBase() {
 
     @Test
@@ -415,7 +417,7 @@ class MockitoTest : TestBase() {
     @Test
     fun testMockStubbing_doThrow() {
         /* Given */
-        val mock = mock<Methods> { mock ->
+        val mock = mock<Methods> {
             on { builderMethod() } doThrow IllegalArgumentException()
         }
 
@@ -430,7 +432,7 @@ class MockitoTest : TestBase() {
     @Test
     fun testMockStubbing_doThrowClass() {
         /* Given */
-        val mock = mock<Methods> { mock ->
+        val mock = mock<Methods> {
             on { builderMethod() } doThrow IllegalArgumentException::class
         }
 
@@ -445,7 +447,7 @@ class MockitoTest : TestBase() {
     @Test
     fun testMockStubbing_doThrowVarargs() {
         /* Given */
-        val mock = mock<Methods> { mock ->
+        val mock = mock<Methods> {
             on { builderMethod() }.doThrow(IllegalArgumentException(), UnsupportedOperationException())
         }
 
@@ -467,7 +469,7 @@ class MockitoTest : TestBase() {
     @Test
     fun testMockStubbing_doThrowClassVarargs() {
         /* Given */
-        val mock = mock<Methods> { mock ->
+        val mock = mock<Methods> {
             on { builderMethod() }.doThrow(IllegalArgumentException::class, UnsupportedOperationException::class)
         }
 
@@ -549,7 +551,7 @@ class MockitoTest : TestBase() {
     fun mock_withSettings_defaultAnswer() {
         /* Given */
         val mock = mock<Methods>(
-              withSettings().defaultAnswer(Mockito.RETURNS_MOCKS)
+              withSettings().defaultAnswer(RETURNS_MOCKS)
         )
 
         /* When */
@@ -637,6 +639,210 @@ class MockitoTest : TestBase() {
             mock<ThrowingConstructor>(
                   withSettings().useConstructor()
             )
+        }
+    }
+
+    @Test
+    fun mock_withSettingsAPI_extraInterfaces() {
+        /* Given */
+        val mock = mock<Methods>(
+              extraInterfaces = arrayOf(ExtraInterface::class)
+        )
+
+        /* Then */
+        expect(mock).toBeInstanceOf<ExtraInterface>()
+    }
+
+    @Test
+    fun mock_withSettingsAPI_name() {
+        /* Given */
+        val mock = mock<Methods>(name = "myName")
+
+        /* When */
+        expectErrorWithMessage("myName.stringResult()") on {
+            verify(mock).stringResult()
+        }
+    }
+
+    @Test
+    fun mock_withSettingsAPI_defaultAnswer() {
+        /* Given */
+        val mock = mock<Methods>(defaultAnswer = RETURNS_MOCKS)
+
+        /* When */
+        val result = mock.nonDefaultReturnType()
+
+        /* Then */
+        expect(result).toNotBeNull()
+    }
+
+    @Test
+    fun mock_withSettingsAPI_serializable() {
+        /* Given */
+        val mock = mock<Methods>(serializable = true)
+
+        /* Then */
+        expect(mock).toBeInstanceOf<Serializable>()
+    }
+
+    @Test
+    fun mock_withSettingsAPI_serializableMode() {
+        /* Given */
+        val mock = mock<Methods>(serializableMode = BASIC)
+
+        /* Then */
+        expect(mock).toBeInstanceOf<Serializable>()
+    }
+
+    @Test
+    fun mock_withSettingsAPI_verboseLogging() {
+        /* Given */
+        val out = mock<PrintStream>()
+        System.setOut(out)
+        val mock = mock<Methods>(verboseLogging = true)
+
+        try {
+            /* When */
+            verify(mock).stringResult()
+            fail("Expected an exception")
+        } catch(e: WantedButNotInvoked) {
+            /* Then */
+            verify(out).println("methods.stringResult();")
+        }
+    }
+
+    @Test
+    fun mock_withSettingsAPI_invocationListeners() {
+        /* Given */
+        var bool = false
+        val mock = mock<Methods>(invocationListeners = arrayOf(InvocationListener { bool = true }))
+
+        /* When */
+        mock.stringResult()
+
+        /* Then */
+        expect(bool).toHold()
+    }
+
+    @Test
+    fun mock_withSettingsAPI_stubOnly() {
+        /* Given */
+        val mock = mock<Methods>(stubOnly = true)
+
+        /* Expect */
+        expectErrorWithMessage("is a stubOnly() mock") on {
+
+            /* When */
+            verify(mock).stringResult()
+        }
+    }
+
+    @Test
+    fun mock_withSettingsAPI_useConstructor() {
+        /* Given */
+        expectErrorWithMessage("Unable to create mock instance of type ") on {
+            mock<ThrowingConstructor>(useConstructor = true) {}
+        }
+    }
+
+    @Test
+    fun mockStubbing_withSettingsAPI_extraInterfaces() {
+        /* Given */
+        val mock = mock<Methods>(extraInterfaces = arrayOf(ExtraInterface::class)) {}
+
+        /* Then */
+        expect(mock).toBeInstanceOf<ExtraInterface>()
+    }
+
+    @Test
+    fun mockStubbing_withSettingsAPI_name() {
+        /* Given */
+        val mock = mock<Methods>(name = "myName") {}
+
+        /* When */
+        expectErrorWithMessage("myName.stringResult()") on {
+            verify(mock).stringResult()
+        }
+    }
+
+    @Test
+    fun mockStubbing_withSettingsAPI_defaultAnswer() {
+        /* Given */
+        val mock = mock<Methods>(defaultAnswer = RETURNS_MOCKS) {}
+
+        /* When */
+        val result = mock.nonDefaultReturnType()
+
+        /* Then */
+        expect(result).toNotBeNull()
+    }
+
+    @Test
+    fun mockStubbing_withSettingsAPI_serializable() {
+        /* Given */
+        val mock = mock<Methods>(serializable = true) {}
+
+        /* Then */
+        expect(mock).toBeInstanceOf<Serializable>()
+    }
+
+    @Test
+    fun mockStubbing_withSettingsAPI_serializableMode() {
+        /* Given */
+        val mock = mock<Methods>(serializableMode = BASIC) {}
+
+        /* Then */
+        expect(mock).toBeInstanceOf<Serializable>()
+    }
+
+    @Test
+    fun mockStubbing_withSettingsAPI_verboseLogging() {
+        /* Given */
+        val out = mock<PrintStream>()
+        System.setOut(out)
+        val mock = mock<Methods>(verboseLogging = true) {}
+
+        try {
+            /* When */
+            verify(mock).stringResult()
+            fail("Expected an exception")
+        } catch(e: WantedButNotInvoked) {
+            /* Then */
+            verify(out).println("methods.stringResult();")
+        }
+    }
+
+    @Test
+    fun mockStubbing_withSettingsAPI_invocationListeners() {
+        /* Given */
+        var bool = false
+        val mock = mock<Methods>(invocationListeners = arrayOf(InvocationListener { bool = true })) {}
+
+        /* When */
+        mock.stringResult()
+
+        /* Then */
+        expect(bool).toHold()
+    }
+
+    @Test
+    fun mockStubbing_withSettingsAPI_stubOnly() {
+        /* Given */
+        val mock = mock<Methods>(stubOnly = true) {}
+
+        /* Expect */
+        expectErrorWithMessage("is a stubOnly() mock") on {
+
+            /* When */
+            verify(mock).stringResult()
+        }
+    }
+
+    @Test
+    fun mockStubbing_withSettingsAPI_useConstructor() {
+        /* Given */
+        expectErrorWithMessage("Unable to create mock instance of type ") on {
+            mock<ThrowingConstructor>(useConstructor = true) {}
         }
     }
 


### PR DESCRIPTION
This enhances the settings API.
For example:

```kotlin
val mock = mock<MyClass>(
  name = "myName",
  defaultAnswer = RETURNS_MOCKS
)
```

Fixes #148 