### PR TITLE
Add doAnswer to OngoingStubbing

### DIFF
--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
@@ -224,6 +224,8 @@ fun <T> OngoingStubbing<T>.doThrow(t: Throwable, vararg ts: Throwable): OngoingS
 infix fun <T> OngoingStubbing<T>.doThrow(t: KClass<out Throwable>): OngoingStubbing<T> = thenThrow(t.java)
 fun <T> OngoingStubbing<T>.doThrow(t: KClass<out Throwable>, vararg ts: KClass<out Throwable>): OngoingStubbing<T> = thenThrow(t.java, *ts.map { it.java }.toTypedArray())
 
+infix fun <T> OngoingStubbing<T>.doAnswer(answer: (InvocationOnMock) -> T?): OngoingStubbing<T> = thenAnswer(answer)
+
 fun mockingDetails(toInspect: Any): MockingDetails = Mockito.mockingDetails(toInspect)!!
 fun never(): VerificationMode = Mockito.never()!!
 fun <T : Any> notNull(): T? = Mockito.notNull()

--- a/mockito-kotlin/src/test/kotlin/test/MockitoTest.kt
+++ b/mockito-kotlin/src/test/kotlin/test/MockitoTest.kt
@@ -489,6 +489,34 @@ class MockitoTest : TestBase() {
     }
 
     @Test
+    fun testMockStubbing_doAnswer() {
+        /* Given */
+        val mock = mock<Methods> {
+            on { stringResult() } doAnswer { "result" }
+        }
+
+        /* When */
+        val result = mock.stringResult()
+
+        /* Then */
+        expect(result).toBe("result")
+    }
+
+    @Test
+    fun testMockStubbing_doAnswer_withArgument() {
+        /* Given */
+        val mock = mock<Methods> {
+            on { stringResult(any()) } doAnswer { "${it.arguments[0]}-result" }
+        }
+
+        /* When */
+        val result = mock.stringResult("argument")
+
+        /* Then */
+        expect(result).toBe("argument-result")
+    }
+
+    @Test
     fun mock_withCustomName() {
         /* Given */
         val mock = mock<Methods>("myName")


### PR DESCRIPTION
Fixes #151.

Allows for

```kotlin
mock<MyClass> {
  on { method() } doAnswer { result }
}
```

and

```kotlin
mock<MyClass> {
  on { method() } doAnswer { invocation ->
    invocation.arguments[0]
  }
}
```