### PR TITLE
Added stub extension function

### DIFF
--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
@@ -175,6 +175,8 @@ inline fun <reified T : Any> mock(
     KStubbing(this).stubbing(this)
 }!!
 
+inline fun <T : Any> T.stub(stubbing: KStubbing<T>.(T) -> Unit) = this.apply { KStubbing(this).stubbing(this) }
+
 @Deprecated("Use mock() with optional arguments instead.", ReplaceWith("mock<T>(defaultAnswer = a)"), level = WARNING)
 inline fun <reified T : Any> mock(a: Answer<Any>): T = mock(defaultAnswer = a)
 

--- a/mockito-kotlin/src/test/kotlin/test/MockitoTest.kt
+++ b/mockito-kotlin/src/test/kotlin/test/MockitoTest.kt
@@ -517,6 +517,41 @@ class MockitoTest : TestBase() {
     }
 
     @Test
+    fun testMockStubbingAfterCreatingMock() {
+        val mock = mock<Methods>()
+
+        //create stub after creation of mock
+        mock.stub {
+            on { stringResult() } doReturn "result"
+        }
+
+        /* When */
+        val result = mock.stringResult()
+
+        /* Then */
+        expect(result).toBe("result")
+    }
+
+    @Test
+    fun testOverrideDefaultStub() {
+        /* Given mock with stub */
+        val mock = mock<Methods> {
+            on { stringResult() } doReturn "result1"
+        }
+
+        /* override stub */
+        mock.stub {
+            on { stringResult() } doReturn "result2"
+        }
+
+        /* When */
+        val result = mock.stringResult()
+
+        /* Then */
+        expect(result).toBe("result2")
+    }
+
+    @Test
     fun mock_withCustomName() {
         /* Given */
         val mock = mock<Methods>("myName")


### PR DESCRIPTION
with this method one can define mock for class

`val someMock = mock<Object>()`

and then define stubs in test

`someMock.stub {  
    on { something } doReturn somethingElse  
}`

It is useful when some tests reuse mock object but with different stubbing
