### PR TITLE
Release 1.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,13 @@ language: java
 matrix:
   include:
   - jdk: oraclejdk7
-    env: TERM=dumb MOCK_MAKER=mock-maker-inline KOTLIN_VERSION=1.0.6
+    env: TERM=dumb MOCK_MAKER=mock-maker-inline KOTLIN_VERSION=1.0.7
   - jdk: oraclejdk7
-    env: TERM=dumb MOCK_MAKER=mock-maker-inline KOTLIN_VERSION=1.1.0-beta-38
+    env: TERM=dumb MOCK_MAKER=mock-maker-inline KOTLIN_VERSION=1.1.1
   - jdk: oraclejdk8
-    env: TERM=dumb KOTLIN_VERSION=1.0.6
+    env: TERM=dumb KOTLIN_VERSION=1.0.7
   - jdk: oraclejdk8
-    env: TERM=dumb KOTLIN_VERSION=1.1.0-beta-38
+    env: TERM=dumb KOTLIN_VERSION=1.1.1
 
 
 env:

--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -3,7 +3,7 @@ apply from: './publishing.gradle'
 apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
-    ext.kotlin_version = System.getenv("KOTLIN_VERSION") ?: '1.0.6'
+    ext.kotlin_version = System.getenv("KOTLIN_VERSION") ?: '1.0.7'
 
     repositories {
         mavenCentral()
@@ -28,7 +28,7 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "org.mockito:mockito-core:2.7.5"
+    compile "org.mockito:mockito-core:2.7.21"
 
     /* Tests */
     testCompile "junit:junit:4.12"

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
@@ -175,6 +175,8 @@ inline fun <reified T : Any> mock(
     KStubbing(this).stubbing(this)
 }!!
 
+inline fun <T : Any> T.stub(stubbing: KStubbing<T>.(T) -> Unit) = this.apply { KStubbing(this).stubbing(this) }
+
 @Deprecated("Use mock() with optional arguments instead.", ReplaceWith("mock<T>(defaultAnswer = a)"), level = WARNING)
 inline fun <reified T : Any> mock(a: Answer<Any>): T = mock(defaultAnswer = a)
 

--- a/mockito-kotlin/src/test/kotlin/test/MockitoTest.kt
+++ b/mockito-kotlin/src/test/kotlin/test/MockitoTest.kt
@@ -517,6 +517,41 @@ class MockitoTest : TestBase() {
     }
 
     @Test
+    fun testMockStubbingAfterCreatingMock() {
+        val mock = mock<Methods>()
+
+        //create stub after creation of mock
+        mock.stub {
+            on { stringResult() } doReturn "result"
+        }
+
+        /* When */
+        val result = mock.stringResult()
+
+        /* Then */
+        expect(result).toBe("result")
+    }
+
+    @Test
+    fun testOverrideDefaultStub() {
+        /* Given mock with stub */
+        val mock = mock<Methods> {
+            on { stringResult() } doReturn "result1"
+        }
+
+        /* override stub */
+        mock.stub {
+            on { stringResult() } doReturn "result2"
+        }
+
+        /* When */
+        val result = mock.stringResult()
+
+        /* Then */
+        expect(result).toBe("result2")
+    }
+
+    @Test
     fun mock_withCustomName() {
         /* Given */
         val mock = mock<Methods>("myName")


### PR DESCRIPTION
 - Adds an extension function to stub a mock after its creation ( #158 )
 - Updates Mockito to `2.7.21`
 - Updates Kotlin to `1.0.7`