### PR TITLE
Added support for coroutines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,7 @@ language: java
 matrix:
   include:
   - jdk: oraclejdk7
-    env: TERM=dumb MOCK_MAKER=mock-maker-inline KOTLIN_VERSION=1.0.7
-  - jdk: oraclejdk7
     env: TERM=dumb MOCK_MAKER=mock-maker-inline KOTLIN_VERSION=1.1.1
-  - jdk: oraclejdk8
-    env: TERM=dumb KOTLIN_VERSION=1.0.7
   - jdk: oraclejdk8
     env: TERM=dumb KOTLIN_VERSION=1.1.1
 

--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -3,7 +3,8 @@ apply from: './publishing.gradle'
 apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
-    ext.kotlin_version = System.getenv("KOTLIN_VERSION") ?: '1.0.7'
+    ext.kotlin_version = System.getenv("KOTLIN_VERSION") ?: '1.1.1'
+    ext.kotlinx_version = System.getenv("KOTLINX_VERSION") ?: '0.15'
 
     repositories {
         mavenCentral()
@@ -23,12 +24,14 @@ repositories {
     mavenCentral()
     jcenter()
     maven { url 'http://dl.bintray.com/kotlin/kotlin-eap-1.1' }
+    maven { url 'https://dl.bintray.com/mockito/maven' }
 }
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "org.mockito:mockito-core:2.7.21"
+    compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinx_version"
+    compile "org.mockito:mockito-core:2.8.29"
 
     /* Tests */
     testCompile "junit:junit:4.12"
@@ -69,3 +72,9 @@ task removeTestResources << {
 
 test.dependsOn createTestResources
 test.finalizedBy removeTestResources
+
+kotlin {
+    experimental {
+        coroutines "enable"
+    }
+}

--- a/mockito-kotlin/src/test/kotlin/test/MockTest.kt
+++ b/mockito-kotlin/src/test/kotlin/test/MockTest.kt
@@ -24,8 +24,10 @@ package test/*
  */
 
 import com.nhaarman.expect.expect
+import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.whenever
+import kotlinx.coroutines.experimental.runBlocking
 import org.junit.Test
 import org.mockito.Mockito.RETURNS_DEEP_STUBS
 import java.util.*
@@ -86,7 +88,19 @@ class MockTest : TestBase() {
         expect(cal.time.time).toBe(123L)
     }
 
+    @Test
+    fun suspendingFunction() {
+        val instance = mock<MyCoroutine>()
+
+        runBlocking {
+            whenever(instance.mySuspendingFunction(any())).thenReturn("abc")
+            expect(instance.mySuspendingFunction("foo")).toBe("abc")
+        }
+    }
+
     private interface MyInterface
     private open class MyClass
+    private interface MyCoroutine {
+        suspend fun mySuspendingFunction(a: String): String
+    }
 }
-


### PR DESCRIPTION
This change bumps Kotlin version to 1.1.1 and adds support for coroutines.

There was a fix in Mockito that made it work with Kotlin coroutines (https://github.com/mockito/mockito/pull/1032), so its version has also been bumped.

A new test case was added to ensure that suspending functions are well handled.