### PR TITLE
Use non-deprecated version of constructor to set RETURNS_DEEP_STUBS

### DIFF
--- a/mockito-kotlin/src/test/kotlin/test/MockTest.kt
+++ b/mockito-kotlin/src/test/kotlin/test/MockTest.kt
@@ -81,7 +81,7 @@ class MockTest : TestBase() {
 
     @Test
     fun deepStubs() {
-        val cal: Calendar = mock(RETURNS_DEEP_STUBS)
+        val cal: Calendar = mock(defaultAnswer = RETURNS_DEEP_STUBS)
         whenever(cal.time.time).thenReturn(123L)
         expect(cal.time.time).toBe(123L)
     }


### PR DESCRIPTION
Very small update to test code to use the non-deprecated way of setting RETURNS_DEEP_STUBS. This is helpful because people are likely to use the tests as a sample of how best to do things like this. 