### PR TITLE
Support for batched verifications on same mock, with Spock-like syntax

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0.1-all.zip

--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -46,23 +46,27 @@ dokka {
 javadoc.dependsOn dokka
 
 //Switch inline
-task createTestResources << {
-    def mockMakerFile = new File("$projectDir/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker")
-    if (System.env.MOCK_MAKER != null) {
-        logger.warn("! Using MockMaker ${System.env.MOCK_MAKER}")
-        mockMakerFile.parentFile.mkdirs()
-        mockMakerFile.createNewFile()
-        mockMakerFile.write(System.env.MOCK_MAKER)
-    } else {
-        logger.warn("! Using default MockMaker")
-    }
+task createTestResources {
+	doLast {
+		def mockMakerFile = new File("$projectDir/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker")
+		if (System.env.MOCK_MAKER != null) {
+			logger.warn("! Using MockMaker ${System.env.MOCK_MAKER}")
+			mockMakerFile.parentFile.mkdirs()
+			mockMakerFile.createNewFile()
+			mockMakerFile.write(System.env.MOCK_MAKER)
+		} else {
+			logger.warn("! Using default MockMaker")
+		}
+	}
 }
 
-task removeTestResources << {
-    def mockMakerFile = new File("$projectDir/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker")
-    if (mockMakerFile.exists()) {
-        mockMakerFile.delete()
-    }
+task removeTestResources {
+	doLast {
+		def mockMakerFile = new File("$projectDir/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker")
+		if (mockMakerFile.exists()) {
+			mockMakerFile.delete()
+		}
+	}
 }
 
 test.dependsOn createTestResources

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
@@ -26,7 +26,11 @@
 package com.nhaarman.mockito_kotlin
 
 import com.nhaarman.mockito_kotlin.createinstance.createInstance
-import org.mockito.*
+import org.mockito.InOrder
+import org.mockito.Incubating
+import org.mockito.MockSettings
+import org.mockito.MockingDetails
+import org.mockito.Mockito
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.listeners.InvocationListener
 import org.mockito.mock.SerializableMode
@@ -276,4 +280,18 @@ fun withSettings(
     if (stubOnly) stubOnly()
     if (useConstructor) useConstructor()
     outerInstance?.let { outerInstance(it) }
+}
+
+/**
+ * verify multiple calls on mock
+ * Supports an easier to read style of
+ *
+ * ```
+ * verify(mock) {
+ *     2 * call()
+ * }
+ * ```
+ */
+inline fun <T> verify(mock: T, block: VerifyScope<T>.() -> Unit) {
+	VerifyScope(mock).block()
 }

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/VerifyScope.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/VerifyScope.kt
@@ -1,0 +1,7 @@
+package com.nhaarman.mockito_kotlin
+
+class VerifyScope<T>(val mock: T) {
+	operator inline fun Int.times(call: T.() -> Unit) {
+		com.nhaarman.mockito_kotlin.verify(mock, com.nhaarman.mockito_kotlin.times(this)).call()
+	}
+}

--- a/mockito-kotlin/src/test/kotlin/test/VerifyTest.kt
+++ b/mockito-kotlin/src/test/kotlin/test/VerifyTest.kt
@@ -1,0 +1,58 @@
+package test
+
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import org.junit.Test
+import org.mockito.exceptions.verification.TooLittleActualInvocations
+import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent
+
+class VerifyTest : TestBase() {
+
+	@Test
+	fun verify0Calls() {
+		val iface = mock<TestInterface>()
+
+		verify(iface) {
+			0 * { call(any()) }
+		}
+	}
+
+	@Test
+	fun verifyNCalls() {
+		val iface = mock<TestInterface>()
+
+		iface.call(42)
+		iface.call(42)
+
+		verify(iface) {
+			2 * { call(42) }
+		}
+	}
+
+	@Test(expected = TooLittleActualInvocations::class)
+	fun verifyFailsWithWrongCount() {
+		val iface = mock<TestInterface>()
+
+		iface.call(0)
+
+		verify(iface) {
+			2 * { call(0) }
+		}
+	}
+
+	@Test(expected = ArgumentsAreDifferent::class)
+	fun verifyFailsWithWrongArg() {
+		val iface = mock<TestInterface>()
+
+		iface.call(3)
+
+		verify(iface) {
+			1 * { call(0) }
+		}
+	}
+
+	interface TestInterface {
+		fun call(arg: Int)
+	}
+}


### PR DESCRIPTION
Thank you for submitting a pull request! But first:

 - [x] Can you back your code up with tests?
 - [x] Keep your commits clean: [squash your commits if necessary](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History).

This patch adds support for the following syntax:
```
verify(mock) {
    3 * { call(any()) }
    0 * { other() }
}
```
in addition to the already existing
```
verify(mock, times(3)).call(any())
verify(mock, never()).other()
```

It is inspired by the syntax Spock uses for its verifications and in my opinion easier to read!

I also upgraded the gradle version to the current release and fixed some deprecated build script code