### PR TITLE
Change on to be inline in order to support coroutines

### DIFF
--- a/mockito-kotlin-kt1.1/build.gradle
+++ b/mockito-kotlin-kt1.1/build.gradle
@@ -27,6 +27,17 @@ dependencies {
     compile project(':mockito-kotlin')
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+    compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:0.18"
+
+    /* Tests */
+    testCompile "junit:junit:4.12"
+    testCompile "com.nhaarman:expect.kt:0.6.2"
+}
+
+kotlin {
+    experimental {
+        coroutines 'enable'
+    }
 }
 
 dokka {

--- a/mockito-kotlin-kt1.1/src/test/kotlin/CoroutinesTest.kt
+++ b/mockito-kotlin-kt1.1/src/test/kotlin/CoroutinesTest.kt
@@ -1,0 +1,21 @@
+import com.nhaarman.expect.expect
+import com.nhaarman.mockito_kotlin.mock
+import kotlinx.coroutines.experimental.runBlocking
+import org.junit.Test
+
+interface SuspendedInterface {
+    suspend fun getNumber(): String
+}
+
+class CoroutinesTest {
+    @Test
+    fun testSuspended() {
+        runBlocking {
+            val mock = mock<SuspendedInterface> {
+                on { getNumber() }.thenReturn("123")
+            }
+
+            expect(mock.getNumber()).toBe("123")
+        }
+    }
+}

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
@@ -187,7 +187,7 @@ inline fun <reified T : Any> mock(s: String): T = mock(name = s)
 @Deprecated("Use mock() with optional arguments instead.", level = WARNING)
 inline fun <reified T : Any> mock(s: MockSettings): T = Mockito.mock(T::class.java, s)!!
 
-class KStubbing<out T>(private val mock: T) {
+class KStubbing<out T>(val mock: T) {
     fun <R> on(methodCall: R) = Mockito.`when`(methodCall)
 
     fun <R : Any> onGeneric(methodCall: T.() -> R, c: KClass<R>): OngoingStubbing<R> {
@@ -208,7 +208,7 @@ class KStubbing<out T>(private val mock: T) {
         return onGeneric(methodCall, R::class)
     }
 
-    fun <R> on(methodCall: T.() -> R): OngoingStubbing<R> {
+    inline fun <R> on(methodCall: T.() -> R): OngoingStubbing<R> {
         return try {
             Mockito.`when`(mock.methodCall())
         } catch(e: NullPointerException) {


### PR DESCRIPTION
Suggested fix for #205 

Seems like all the previous tests work. Had to add the tests in the kt1.1 artifact in order to test the coroutines.