### PR TITLE
Support Kotlin 1.2.0 and set default Kotlin version to 1.1.50

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,13 @@ language: java
 matrix:
   include:
   - jdk: oraclejdk8
-    env: TERM=dumb MOCK_MAKER=mock-maker-inline KOTLIN_VERSION=1.0.7
-  - jdk: oraclejdk8
     env: TERM=dumb MOCK_MAKER=mock-maker-inline KOTLIN_VERSION=1.1.50
   - jdk: oraclejdk8
-    env: TERM=dumb KOTLIN_VERSION=1.0.7
+    env: TERM=dumb MOCK_MAKER=mock-maker-inline KOTLIN_VERSION=1.2.0
   - jdk: oraclejdk8
     env: TERM=dumb KOTLIN_VERSION=1.1.50
+  - jdk: oraclejdk8
+    env: TERM=dumb KOTLIN_VERSION=1.2.0
 
 
 env:

--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -3,7 +3,7 @@ apply from: '../publishing.gradle'
 apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
-    ext.kotlin_version = System.getenv("KOTLIN_VERSION") ?: '1.0.7'
+    ext.kotlin_version = System.getenv("KOTLIN_VERSION") ?: '1.1.50'
 
     repositories {
         mavenCentral()

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/createinstance/InstanceCreator.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/createinstance/InstanceCreator.kt
@@ -11,6 +11,7 @@ import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 import kotlin.reflect.*
 import kotlin.reflect.jvm.*
+import kotlin.reflect.full.starProjectedType
 import java.lang.reflect.Array as JavaArray
 
 internal class InstanceCreator() : NonNullProvider {
@@ -52,10 +53,10 @@ internal class InstanceCreator() : NonNullProvider {
     private fun <T : Any> KClass<T>.easiestConstructor(): KFunction<T> {
         return constructors
                 .sortedBy { it.parameters.withoutOptionalParameters().size }
-                .withoutParametersOfType(this.defaultType)
+                .withoutParametersOfType(this.starProjectedType)
                 .withoutArrayParameters()
                 .firstOrNull() ?: constructors.sortedBy { it.parameters.withoutOptionalParameters().size }
-                .withoutParametersOfType(this.defaultType)
+                .withoutParametersOfType(this.starProjectedType)
                 .first()
     }
 
@@ -85,7 +86,7 @@ internal class InstanceCreator() : NonNullProvider {
     private fun KClass<*>.isArray() = java.isArray
     private fun KClass<*>.isClassObject() = jvmName.equals("java.lang.Class")
     private fun KClass<*>.isPrimitive() =
-            java.isPrimitive || !defaultType.isMarkedNullable && simpleName in arrayOf(
+            java.isPrimitive || !starProjectedType.isMarkedNullable && simpleName in arrayOf(
                     "Boolean",
                     "Byte",
                     "Short",


### PR DESCRIPTION
Added Kotlin 1.2.0 support.

- Use kotlin.reflect.full.starProjectedType instead of kotlin.reflect.defaultType
  - extensions in `jvm.reflect` package was removed in Kotlin 1.2.0
- Set default Kotlin version to 1.1.50
  - `kotlin.reflect.full` package was added in Kotlin 1.1.0
  - **[important]** Applying this change makes it impossible to support Kotlin 1.0.x.
- https://kotlinlang.org/docs/reference/whatsnew11.html#kotlinreflectfull
- https://kotlinlang.org/docs/reference/whatsnew12.html#kotlin-standard-library-artifacts-and-split-packages

Thank you for submitting a pull request! But first:

 - [x] Can you back your code up with tests?
 - [x] Keep your commits clean: [squash your commits if necessary](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History).

We want to use Kotlin 1.2.0 as soon as possible. Please check this 🙇 