### PR TITLE
Improve error message on NPE in `on`

### DIFF
--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockitokotlin2/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockitokotlin2/Mockito.kt
@@ -215,7 +215,7 @@ class KStubbing<out T>(private val mock: T) {
         return try {
             Mockito.`when`(mock.methodCall())
         } catch (e: NullPointerException) {
-            throw MockitoKotlinException("NullPointerException thrown when stubbing. If you are trying to stub a generic method, try `onGeneric` instead.", e)
+            throw MockitoKotlinException("NullPointerException thrown when stubbing.\nThis may be due to two reasons:\n\t- The method you're trying to stub threw an NPE: look at the stack trace below;\n\t- You're trying to stub a generic method: try `onGeneric` instead.", e)
         }
     }
 }

--- a/mockito-kotlin/src/test/kotlin/test/Classes.kt
+++ b/mockito-kotlin/src/test/kotlin/test/Classes.kt
@@ -36,6 +36,8 @@ open class Open {
     }
 
     open fun stringResult() = "Default"
+
+    fun throwsNPE(): Any = throw NullPointerException("Test")
 }
 
 class Closed

--- a/mockito-kotlin/src/test/kotlin/test/MockitoTest.kt.orig
+++ b/mockito-kotlin/src/test/kotlin/test/MockitoTest.kt.orig
@@ -9,7 +9,10 @@ import org.mockito.exceptions.base.MockitoAssertionError
 import org.mockito.exceptions.verification.WantedButNotInvoked
 import org.mockito.listeners.InvocationListener
 import org.mockito.mock.SerializableMode.BASIC
+<<<<<<< HEAD
 import org.mockito.stubbing.Answer
+=======
+>>>>>>> 91437b8... Improve error message on NPE in
 import java.io.*
 
 


### PR DESCRIPTION
Fixes #195 

The error message becomes:

```
com.nhaarman.mockitokotlin2.MockitoKotlinException: NullPointerException thrown when stubbing.
This may be due to two reasons:
	- The method you're trying to stub threw an NPE: look at the stack trace below;
	- You're trying to stub a generic method: try `onGeneric` instead.

	at com.nhaarman.mockitokotlin2.KStubbing.on(Mockito.kt:218)
	at test.MockitoTest.doReturn_throwsNPE(MockitoTest.kt:982)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Caused by: java.lang.NullPointerException: Test
	at test.Open.throwsNPE(Classes.kt:40)
	at test.MockitoTest$doReturn_throwsNPE$1$1.invoke(MockitoTest.kt:982)
	at test.MockitoTest$doReturn_throwsNPE$1$1.invoke(MockitoTest.kt:73)
	at com.nhaarman.mockitokotlin2.KStubbing.on(Mockito.kt:216)
	... 25 more
```