### PR TITLE
Add dsl stubbing to spied classes.

### DIFF
--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockitokotlin2/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockitokotlin2/Mockito.kt
@@ -243,7 +243,11 @@ fun <T> reset(vararg mocks: T) = Mockito.reset(*mocks)
 fun <T> same(value: T): T = Mockito.same(value) ?: value
 
 inline fun <reified T : Any> spy(): T = Mockito.spy(T::class.java)!!
+inline fun <reified T : Any> spy(stubbing: KStubbing<T>.(T) -> Unit ): T = Mockito.spy(T::class.java)
+        .apply { KStubbing(this).stubbing(this) }!!
 fun <T> spy(value: T): T = Mockito.spy(value)!!
+inline fun <reified T> spy(value: T, stubbing: KStubbing<T>.(T) -> Unit): T = spy(value)
+        .apply { KStubbing(this).stubbing(this) }!!
 
 fun timeout(millis: Long): VerificationWithTimeout = Mockito.timeout(millis)!!
 fun times(numInvocations: Int): VerificationMode = Mockito.times(numInvocations)!!

--- a/mockito-kotlin/src/test/kotlin/test/SpyTest.kt
+++ b/mockito-kotlin/src/test/kotlin/test/SpyTest.kt
@@ -71,7 +71,7 @@ class SpyTest : TestBase() {
     fun doNothingWithSpy() {
         val date = spy(Date(0))
         doNothing().whenever(date).time = 5L
-        date.time = 5L;
+        date.time = 5L
         expect(date.time).toBe(0L)
     }
 
@@ -88,6 +88,28 @@ class SpyTest : TestBase() {
         doReturn(123L).whenever(date).time
         doCallRealMethod().whenever(date).time
         expect(date.time).toBe(0L)
+    }
+
+    @Test
+    fun doReturnWithDefaultInstanceSpyStubbing() {
+        val timeVal = 12L
+        
+        val dateSpy = spy<Date> {
+            on { time } doReturn timeVal
+        }
+
+        expect(dateSpy.time).toBe(timeVal)
+    }
+
+    @Test
+    fun doReturnWithSpyStubbing() {
+        val timeVal = 15L
+        
+        val dateSpy = spy(Date(0)) {
+            on { time } doReturn timeVal
+        }
+
+        expect(dateSpy.time).toBe(timeVal)
     }
 
     private interface MyInterface


### PR DESCRIPTION
Rebased onto branch `2.x`. Original: #182.

Now it is possible to describe spied classes mock behaviour in dsl form as
it was already possible with common mocks.

Signed-off-by: Yahor Berdnikau <egorr.berd@gmail.com>

