### PR TITLE
better inOrder for single arguments

### DIFF
--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/Mockito.kt
@@ -115,7 +115,13 @@ fun <T> eq(value: T): T = Mockito.eq(value) ?: value
 fun ignoreStubs(vararg mocks: Any): Array<out Any> = Mockito.ignoreStubs(*mocks)!!
 fun inOrder(vararg mocks: Any): InOrder = Mockito.inOrder(*mocks)!!
 fun inOrder(vararg mocks: Any, evaluation: InOrder.() -> Unit) = Mockito.inOrder(*mocks).evaluation()
+inline fun <T>T.inOrder(block: InOrderOnType<T>.() -> Any){
+    block.invoke(InOrderOnType<T>(this))
+}
 
+class InOrderOnType<T>(private val t: T) : InOrder by inOrder(t as Any) {
+    fun verify() = verify(t)
+}
 inline fun <reified T : Any> isA(): T = Mockito.isA(T::class.java) ?: createInstance<T>()
 fun <T : Any> isNotNull(): T? = Mockito.isNotNull()
 fun <T : Any> isNull(): T? = Mockito.isNull()

--- a/mockito-kotlin/src/test/kotlin/test/MockitoTest.kt
+++ b/mockito-kotlin/src/test/kotlin/test/MockitoTest.kt
@@ -226,6 +226,23 @@ class MockitoTest : TestBase() {
     }
 
     @Test
+    fun testInOrderWithReceiver() {
+        /* Given */
+        val mock = mock<Methods>()
+
+        /* When */
+        mock.string("")
+        mock.int(0)
+
+        /* Then */
+        mock.inOrder() {
+            verify().string(any())
+            verify().int(any())
+            verifyNoMoreInteractions()
+        }
+    }
+
+    @Test
     fun testClearInvocations() {
         val mock = mock<Methods>().apply {
             string("")


### PR DESCRIPTION
when using inOrder with a single argument I need to repeat myself:
```
   @Test
    fun writesToBundle() {
        tested.onSaveInstanceState(bundle)
        inOrder(bundle).apply {
            verify(bundle).putString("secretKey1", "1")
            verify(bundle).putInt("secretKey2", 2)
            verifyNoMoreInteractions()
        }
    }
```
see how the bundle needs to be repeated.
now I can do:

```
   @Test
    fun writesToBundle() {
        tested.onSaveInstanceState(bundle)
        bundle.inOrder {
            verify().putString("secretKey1", "1")
            verify().putInt("secretKey2", 2)
            verifyNoMoreInteractions()
        }
    }
```
I dont like that I need to expose the new class so if you have better solution let me know :)
but need to make sure that this is InOrder and that I have verify without argument