### PR TITLE
extension function for spies

### DIFF
--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockitokotlin2/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockitokotlin2/Mockito.kt
@@ -243,6 +243,9 @@ inline fun <reified T : Any> spy(stubbing: KStubbing<T>.(T) -> Unit ): T = Mocki
 fun <T> spy(value: T): T = Mockito.spy(value)!!
 inline fun <reified T> spy(value: T, stubbing: KStubbing<T>.(T) -> Unit): T = spy(value)
         .apply { KStubbing(this).stubbing(this) }!!
+fun <T> T.spied() : T = Mockito.spy(this)!!
+inline fun <reified T> T.spied(stubbing: KStubbing<T>.(T) -> Unit) : T = Mockito.spy(this)
+        .apply { KStubbing(this).stubbing(this) }!!
 
 fun timeout(millis: Long): VerificationWithTimeout = Mockito.timeout(millis)!!
 fun times(numInvocations: Int): VerificationMode = Mockito.times(numInvocations)!!

--- a/mockito-kotlin/src/test/kotlin/test/SpyTest.kt
+++ b/mockito-kotlin/src/test/kotlin/test/SpyTest.kt
@@ -112,6 +112,27 @@ class SpyTest : TestBase() {
         expect(dateSpy.time).toBe(timeVal)
     }
 
+    @Test
+    fun postfixSpyInterfaceInstance() {
+        /* When */
+        val result = interfaceInstance.spied()
+
+        /* Then */
+        expect(result).toNotBeNull()
+    }
+
+    @Test
+    fun doReturnWithPostfixSpyStubbing() {
+        val timeVal = 15L
+
+        val dateSpy = Date(0).spied {
+            on { time } doReturn timeVal
+        }
+
+        expect(dateSpy.time).toBe(timeVal)
+    }
+
+
     private interface MyInterface
     private open class MyClass : MyInterface
     private class ClosedClass


### PR DESCRIPTION
spy should make use of extensions functions, as they are based on existing objects, so no need to use same syntax as mock :)

it reads much nicer:

```kotlin
      val dateSpy = Date(0).spy()
```
or
```kotlin
      val dateSpy = Date(0).spy {
            on { time } doReturn timeVal
        }
```

had to rename to *spied* as would have the same jvm syntax as the latest merge to spy syntax

```kotlin
      val dateSpy = Date(0).spied()
```
