### PR TITLE
added isMock and isSpy as extension function

### DIFF
--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockitokotlin2/Mockito.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockitokotlin2/Mockito.kt
@@ -26,6 +26,7 @@
 package com.nhaarman.mockitokotlin2
 
 import org.mockito.*
+import org.mockito.internal.util.MockUtil
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.listeners.InvocationListener
 import org.mockito.mock.SerializableMode
@@ -243,6 +244,9 @@ inline fun <reified T : Any> spy(stubbing: KStubbing<T>.(T) -> Unit ): T = Mocki
 fun <T> spy(value: T): T = Mockito.spy(value)!!
 inline fun <reified T> spy(value: T, stubbing: KStubbing<T>.(T) -> Unit): T = spy(value)
         .apply { KStubbing(this).stubbing(this) }!!
+
+fun Any.isSpy() = MockUtil.isSpy(this)
+fun Any.isMock() = MockUtil.isMock(this)
 
 fun timeout(millis: Long): VerificationWithTimeout = Mockito.timeout(millis)!!
 fun times(numInvocations: Int): VerificationMode = Mockito.times(numInvocations)!!

--- a/mockito-kotlin/src/test/kotlin/test/MockitoTest.kt
+++ b/mockito-kotlin/src/test/kotlin/test/MockitoTest.kt
@@ -11,6 +11,7 @@ import org.mockito.listeners.InvocationListener
 import org.mockito.mock.SerializableMode.BASIC
 import org.mockito.stubbing.Answer
 import java.io.*
+import java.util.*
 
 
 /*
@@ -1066,4 +1067,14 @@ class MockitoTest : TestBase() {
         /* Then */
         expect(mock.stringResult()).toBe("result")
     }
+
+    @Test
+    fun checkIfMock() {
+        val date = Date(0)
+        val dateMock = mock<Date>()
+
+        expect(dateMock.isMock()).toBe(true)
+        expect(date.isMock()).toBe(false)
+    }
+
 }

--- a/mockito-kotlin/src/test/kotlin/test/SpyTest.kt
+++ b/mockito-kotlin/src/test/kotlin/test/SpyTest.kt
@@ -112,6 +112,17 @@ class SpyTest : TestBase() {
         expect(dateSpy.time).toBe(timeVal)
     }
 
+
+    @Test
+    fun checkIfSpy() {
+        val date = Date(0)
+        val dateSpy = spy(date)
+
+        expect(dateSpy.isSpy()).toBe(true)
+        expect(date.isSpy()).toBe(false)
+    }
+
+
     private interface MyInterface
     private open class MyClass : MyInterface
     private class ClosedClass


### PR DESCRIPTION
Mockito contains isMock and isSpy

Kotlin offers useful extension function:
so instead of:

``` kotlin
isMock(datemock)
```
you can write

``` kotlin
dateMock.isMock()
```