### PR TITLE
Simplified argument captor API

### DIFF
--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/ArgumentCaptor.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/ArgumentCaptor.kt
@@ -29,8 +29,10 @@ import com.nhaarman.mockito_kotlin.createinstance.createInstance
 import org.mockito.ArgumentCaptor
 import kotlin.reflect.KClass
 
-inline fun <reified T : Any> argumentCaptor(param: KArgumentCaptor<T>.() -> Unit = {}): KArgumentCaptor<T> = KArgumentCaptor(ArgumentCaptor.forClass(T::class.java), T::class)
-inline fun <reified T : Any> nullableArgumentCaptor(param: KArgumentCaptor<T?>.() -> Unit = {}): KArgumentCaptor<T?> = KArgumentCaptor(ArgumentCaptor.forClass(T::class.java), T::class)
+inline fun <reified T : Any> argumentCaptor(): KArgumentCaptor<T> = KArgumentCaptor(ArgumentCaptor.forClass(T::class.java), T::class)
+inline fun <reified T : Any> argumentCaptor(param: KArgumentCaptor<T>.() -> Unit): KArgumentCaptor<T> = KArgumentCaptor(ArgumentCaptor.forClass(T::class.java), T::class)
+inline fun <reified T : Any> nullableArgumentCaptor(): KArgumentCaptor<T?> = KArgumentCaptor(ArgumentCaptor.forClass(T::class.java), T::class)
+inline fun <reified T : Any> nullableArgumentCaptor(param: KArgumentCaptor<T?>.() -> Unit): KArgumentCaptor<T?> = KArgumentCaptor(ArgumentCaptor.forClass(T::class.java), T::class)
 
 inline fun <reified T : Any> capture(captor: ArgumentCaptor<T>): T = captor.capture() ?: createInstance<T>()
 

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/ArgumentCaptor.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/ArgumentCaptor.kt
@@ -29,10 +29,8 @@ import com.nhaarman.mockito_kotlin.createinstance.createInstance
 import org.mockito.ArgumentCaptor
 import kotlin.reflect.KClass
 
-inline fun <reified T : Any> argumentCaptor(): KArgumentCaptor<T> = KArgumentCaptor(ArgumentCaptor.forClass(T::class.java), T::class)
-inline fun <reified T : Any> argumentCaptor(param: KArgumentCaptor<T>.() -> Unit): KArgumentCaptor<T> = KArgumentCaptor(ArgumentCaptor.forClass(T::class.java), T::class)
-inline fun <reified T : Any> nullableArgumentCaptor(): KArgumentCaptor<T?> = KArgumentCaptor(ArgumentCaptor.forClass(T::class.java), T::class)
-inline fun <reified T : Any> nullableArgumentCaptor(param: KArgumentCaptor<T?>.() -> Unit): KArgumentCaptor<T?> = KArgumentCaptor(ArgumentCaptor.forClass(T::class.java), T::class)
+inline fun <reified T : Any> argumentCaptor(param: KArgumentCaptor<T>.() -> Unit = {}): KArgumentCaptor<T> = KArgumentCaptor(ArgumentCaptor.forClass(T::class.java), T::class)
+inline fun <reified T : Any> nullableArgumentCaptor(param: KArgumentCaptor<T?>.() -> Unit = {}): KArgumentCaptor<T?> = KArgumentCaptor(ArgumentCaptor.forClass(T::class.java), T::class)
 
 inline fun <reified T : Any> capture(captor: ArgumentCaptor<T>): T = captor.capture() ?: createInstance<T>()
 

--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/ArgumentCaptor.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockito_kotlin/ArgumentCaptor.kt
@@ -30,7 +30,9 @@ import org.mockito.ArgumentCaptor
 import kotlin.reflect.KClass
 
 inline fun <reified T : Any> argumentCaptor(): KArgumentCaptor<T> = KArgumentCaptor(ArgumentCaptor.forClass(T::class.java), T::class)
+inline fun <reified T : Any> argumentCaptor(param: KArgumentCaptor<T>.() -> Unit): KArgumentCaptor<T> = KArgumentCaptor(ArgumentCaptor.forClass(T::class.java), T::class)
 inline fun <reified T : Any> nullableArgumentCaptor(): KArgumentCaptor<T?> = KArgumentCaptor(ArgumentCaptor.forClass(T::class.java), T::class)
+inline fun <reified T : Any> nullableArgumentCaptor(param: KArgumentCaptor<T?>.() -> Unit): KArgumentCaptor<T?> = KArgumentCaptor(ArgumentCaptor.forClass(T::class.java), T::class)
 
 inline fun <reified T : Any> capture(captor: ArgumentCaptor<T>): T = captor.capture() ?: createInstance<T>()
 


### PR DESCRIPTION
This will simplify ArgumentCaptor code

```
        //old (still working)
        argumentCaptor<String>().apply {
            verify(mailRepository).sendEmail(capture())
            firstValue shouldEqual "A"
        }

        nullableArgumentCaptor<String>().apply {
            firstValue shouldEqual null
        }

        // new simplified overload usage
       argumentCaptor<String> {
            verify(mailRepository).sendEmail(capture())
            firstValue shouldEqual "A"
        }

        nullableArgumentCaptor<String> {
            firstValue shouldEqual null
        }
```

I needed to add another overload since older version of Kotlin does not support default values for functional parameters