### PR TITLE
Make inOrder inline

### DIFF
--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockitokotlin2/Verification.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockitokotlin2/Verification.kt
@@ -192,7 +192,7 @@ fun inOrder(vararg mocks: Any): InOrder {
  *
  * Alias for [Mockito.inOrder].
  */
-fun inOrder(
+inline fun inOrder(
     vararg mocks: Any,
     evaluation: InOrder.() -> Unit
 ) {


### PR DESCRIPTION
This code currently does not compile:

```kotlin
private interface SomeSuspendingClass {
    suspend fun doWork()
}

@Test
fun verifySuspendMethod() = runBlocking {
    val testSubject : SomeSuspendingClass = mock()
    val testSubject2 : SomeSuspendingClass = mock()

    //...

    inOrder(testSubject, testSubject2) {
        verify(testSubject).doWork()
        verify(testSubject2).doWork()
    }
}
```

Even though there is `runBlocking` wrapper outside, `inOrder` runs separately from it. Only workaround for current mockito-kotlin is ugly double runBlocking:

```kotlin
private interface SomeSuspendingClass {
    suspend fun doWork()
}

@Test
fun verifySuspendMethod() = runBlocking {
    val testSubject : SomeSuspendingClass = mock()
    val testSubject2 : SomeSuspendingClass = mock()

    //...

    inOrder(testSubject, testSubject2) {
        runBlocking {
            verify(testSubject).doWork()
            verify(testSubject2).doWork()
        }
    }
}
```

Making `inOrder` helper function `inline` fixes this issue.