### PR TITLE
Simplified argument captor API (originally #242)

### DIFF
--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockitokotlin2/ArgumentCaptor.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockitokotlin2/ArgumentCaptor.kt
@@ -37,10 +37,24 @@ inline fun <reified T : Any> argumentCaptor(): KArgumentCaptor<T> {
 }
 
 /**
+ * Creates a [KArgumentCaptor] for given type, taking in a lambda to allow fast verification.
+ */
+inline fun <reified T : Any> argumentCaptor(f: KArgumentCaptor<T>.() -> Unit): KArgumentCaptor<T> {
+    return argumentCaptor<T>().apply(f)
+}
+
+/**
  * Creates a [KArgumentCaptor] for given nullable type.
  */
 inline fun <reified T : Any> nullableArgumentCaptor(): KArgumentCaptor<T?> {
     return KArgumentCaptor(ArgumentCaptor.forClass(T::class.java), T::class)
+}
+
+/**
+ * Creates a [KArgumentCaptor] for given nullable type, taking in a lambda to allow fast verification.
+ */
+inline fun <reified T : Any> nullableArgumentCaptor(f: KArgumentCaptor<T?>.() -> Unit): KArgumentCaptor<T?> {
+    return nullableArgumentCaptor<T>().apply(f)
 }
 
 /**

--- a/tests/src/test/kotlin/test/ArgumentCaptorTest.kt
+++ b/tests/src/test/kotlin/test/ArgumentCaptorTest.kt
@@ -1,6 +1,7 @@
 package test
 
 import com.nhaarman.expect.expect
+import com.nhaarman.expect.expectErrorWithMessage
 import com.nhaarman.mockitokotlin2.*
 import org.junit.Test
 import java.util.*
@@ -115,6 +116,38 @@ class ArgumentCaptorTest : TestBase() {
             verify(m).int(capture())
 
             expect(secondValue).toBe(2)
+        }
+    }
+
+    @Test
+    fun argumentCaptor_withSingleValue_lambda() {
+        /* Given */
+        val date: Date = mock()
+
+        /* When */
+        date.time = 5L
+
+        /* Then */
+        argumentCaptor<Long> {
+            verify(date).time = capture()
+            expect(lastValue).toBe(5L)
+        }
+    }
+
+    @Test
+    fun argumentCaptor_withSingleValue_lambda_properlyFails() {
+        /* Given */
+        val date: Date = mock()
+
+        /* When */
+        date.time = 5L
+
+        /* Then */
+        expectErrorWithMessage("Expected: 3 but was: 5") on {
+            argumentCaptor<Long> {
+                verify(date).time = capture()
+                expect(lastValue).toBe(3L)
+            }
         }
     }
 }


### PR DESCRIPTION
This will simplify ArgumentCaptor code

```
        //old (still working)
        argumentCaptor<String>().apply {
            verify(mailRepository).sendEmail(capture())
            firstValue shouldEqual "A"
        }

        nullableArgumentCaptor<String>().apply {
            firstValue shouldEqual null
        }

        // new simplified overload usage
       argumentCaptor<String> {
            verify(mailRepository).sendEmail(capture())
            firstValue shouldEqual "A"
        }

        nullableArgumentCaptor<String> {
            firstValue shouldEqual null
        }
```

This is a fixed version of #242, rebased onto `2.x`.