### PR TITLE
Updated kotlin version to 1.2.41

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     dependencies {
         classpath "io.spring.gradle:spring-bintray-plugin:0.9.0"
     }
+    ext.kotlin_version = '1.2.41'
 }
 
 plugins {

--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -3,8 +3,6 @@ apply from: '../publishing.gradle'
 apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
-    ext.kotlin_version = "1.2.20"
-
     repositories {
         mavenCentral()
         jcenter()
@@ -32,7 +30,7 @@ dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'com.nhaarman:expect.kt:1.0.0'
 
-    testCompile  "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    testCompile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testCompile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.19.3'
 
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:0.21"

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -1,7 +1,4 @@
 buildscript {
-    ext.kotlin_version = '1.2.20'
-    ext.kotlin_version = System.getenv("KOTLIN_VERSION") ?: '1.0.7'
-
     repositories {
         mavenCentral()
     }
@@ -19,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    compile files("${rootProject.projectDir}/mockito-kotlin/build/libs/mockito-kotlin-${rootProject.ext.versionName}.jar")
+    compile project(':mockito-kotlin')
 
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.mockito:mockito-core:2.13.0"


### PR DESCRIPTION
- Updates kotlin to 1.2.41
- Makes the kotlin version variable available across all modules
- Uses gradle project dependencies inside test module, so that you can just run ./gradlew test without manually compiling first