### PR TITLE
Support mocking with constructor arguments

### DIFF
--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockitokotlin2/Mocking.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockitokotlin2/Mocking.kt
@@ -59,7 +59,7 @@ inline fun <reified T : Any> mock(
     verboseLogging: Boolean = false,
     invocationListeners: Array<InvocationListener>? = null,
     stubOnly: Boolean = false,
-    @Incubating useConstructor: Boolean = false,
+    @Incubating useConstructor: UseConstructor? = null,
     @Incubating outerInstance: Any? = null
 ): T {
     return Mockito.mock(
@@ -105,7 +105,7 @@ inline fun <reified T : Any> mock(
     verboseLogging: Boolean = false,
     invocationListeners: Array<InvocationListener>? = null,
     stubOnly: Boolean = false,
-    @Incubating useConstructor: Boolean = false,
+    @Incubating useConstructor: UseConstructor? = null,
     @Incubating outerInstance: Any? = null,
     stubbing: KStubbing<T>.(T) -> Unit
 ): T {
@@ -153,7 +153,7 @@ fun withSettings(
     verboseLogging: Boolean = false,
     invocationListeners: Array<InvocationListener>? = null,
     stubOnly: Boolean = false,
-    @Incubating useConstructor: Boolean = false,
+    @Incubating useConstructor: UseConstructor? = null,
     @Incubating outerInstance: Any? = null
 ): MockSettings = Mockito.withSettings().apply {
     extraInterfaces?.let { extraInterfaces(*it.map { it.java }.toTypedArray()) }
@@ -165,10 +165,23 @@ fun withSettings(
     if (verboseLogging) verboseLogging()
     invocationListeners?.let { invocationListeners(*it) }
     if (stubOnly) stubOnly()
-    if (useConstructor) useConstructor()
+    useConstructor?.let { useConstructor(*it.args) }
     outerInstance?.let { outerInstance(it) }
 }
 
+class UseConstructor private constructor(val args: Array<Any>) {
+
+    companion object {
+
+        /** Invokes the parameterless constructor. */
+        fun parameterless() = UseConstructor(emptyArray())
+
+        /** Invokes a constructor with given arguments. */
+        fun withArguments(vararg arguments: Any): UseConstructor {
+            return UseConstructor(arguments.asList().toTypedArray())
+        }
+    }
+}
 
 @Deprecated(
       "Use mock() with optional arguments instead.",

--- a/tests/src/test/kotlin/test/Classes.kt
+++ b/tests/src/test/kotlin/test/Classes.kt
@@ -75,6 +75,22 @@ abstract class ThrowingConstructor {
     }
 }
 
+abstract class ThrowingConstructorWithArgument {
+
+    constructor(s: String) {
+        error("Error in constructor: $s")
+    }
+}
+
+abstract class NonThrowingConstructorWithArgument {
+
+    constructor() {
+        error("Error in constructor")
+    }
+
+    constructor(s: String)
+}
+
 interface GenericMethods<T> {
     fun genericMethod(): T
     fun nullableReturnType(): T?

--- a/tests/src/test/kotlin/test/MockingTest.kt
+++ b/tests/src/test/kotlin/test/MockingTest.kt
@@ -3,10 +3,10 @@ package test
 import com.nhaarman.expect.expect
 import com.nhaarman.expect.expectErrorWithMessage
 import com.nhaarman.expect.fail
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
+import com.nhaarman.mockitokotlin2.*
+import com.nhaarman.mockitokotlin2.UseConstructor.Companion
+import com.nhaarman.mockitokotlin2.UseConstructor.Companion.parameterless
+import com.nhaarman.mockitokotlin2.UseConstructor.Companion.withArguments
 import org.junit.Test
 import org.mockito.Mockito
 import org.mockito.exceptions.verification.WantedButNotInvoked
@@ -101,7 +101,6 @@ class MockingTest : TestBase() {
         /* Then */
         expect(result).toBe("B")
     }
-
 
 
     @Test
@@ -215,8 +214,25 @@ class MockingTest : TestBase() {
     fun mock_withSettingsAPI_useConstructor() {
         /* Given */
         expectErrorWithMessage("Unable to create mock instance of type ") on {
-            mock<ThrowingConstructor>(useConstructor = true) {}
+            mock<ThrowingConstructor>(useConstructor = parameterless()) {}
         }
+    }
+
+    @Test
+    fun mock_withSettingsAPI_useConstructorWithArguments_failing() {
+        /* Given */
+        expectErrorWithMessage("Unable to create mock instance of type ") on {
+            mock<ThrowingConstructorWithArgument>(useConstructor = withArguments("Test")) {}
+        }
+    }
+
+    @Test
+    fun mock_withSettingsAPI_useConstructorWithArguments() {
+        /* When */
+        val result = mock<NonThrowingConstructorWithArgument>(useConstructor = withArguments("Test")) {}
+
+        /* Then */
+        expect(result).toNotBeNull()
     }
 
     @Test
@@ -316,7 +332,7 @@ class MockingTest : TestBase() {
     fun mockStubbing_withSettingsAPI_useConstructor() {
         /* Given */
         expectErrorWithMessage("Unable to create mock instance of type ") on {
-            mock<ThrowingConstructor>(useConstructor = true) {}
+            mock<ThrowingConstructor>(useConstructor = parameterless()) {}
         }
     }
 


### PR DESCRIPTION
Fixes #243 

This breaks code that currently uses `useConstructor = true`, which can simply be replaced by `useConstructor = parameterless()`.