### PR TITLE
Inline `whenever` to let Mockito's UnfinishedStubbing messages work

### DIFF
--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockitokotlin2/OngoingStubbing.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockitokotlin2/OngoingStubbing.kt
@@ -37,7 +37,8 @@ import kotlin.reflect.KClass
  *
  * Alias for [Mockito.when].
  */
-fun <T> whenever(methodCall: T): OngoingStubbing<T> {
+@Suppress("NOTHING_TO_INLINE")
+inline fun <T> whenever(methodCall: T): OngoingStubbing<T> {
     return Mockito.`when`(methodCall)!!
 }
 

--- a/tests/src/test/kotlin/test/OngoingStubbingTest.kt
+++ b/tests/src/test/kotlin/test/OngoingStubbingTest.kt
@@ -7,6 +7,7 @@ import com.nhaarman.mockitokotlin2.*
 import org.junit.Assume.assumeFalse
 import org.junit.Test
 import org.mockito.Mockito
+import org.mockito.exceptions.misusing.UnfinishedStubbingException
 import org.mockito.stubbing.Answer
 
 class OngoingStubbingTest : TestBase() {
@@ -318,5 +319,21 @@ class OngoingStubbingTest : TestBase() {
 
         /* Then */
         expect(mock.stringResult()).toBe("result")
+    }
+
+    @Test
+    fun testMockitoStackOnUnfinishedStubbing() {
+        /* Given */
+        val mock = mock<Open>()
+        whenever(mock.stringResult())
+
+        /* When */
+        try {
+            mock.stringResult()
+        } catch(e: UnfinishedStubbingException) {
+            /* Then */
+            expect(e.message).toContain("Unfinished stubbing detected here:")
+            expect(e.message).toContain("-> at test.OngoingStubbingTest.testMockitoStackOnUnfinishedStubbing")
+        }
     }
 }


### PR DESCRIPTION
When Mockito detects unfinished stubbing, it will spit out an error containing:
```
Unfinished stubbing detected here:
-> at com.nhaarman.mockitokotlin2.OngoingStubbingKt.whenever(OngoingStubbing.kt:42)
```

This is not useful in helping users track down unfinished stubbing.  Instead, we inline `whenever`
to make it read as:
```
Unfinished stubbing detected here:
-> at com.MyTest.testMyThing(MyTest.kt:785)
```