### PR TITLE
Replace OngoingStubbing<T>.doReturn(List<T>) with doReturnConsecutively.

### DIFF
--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockitokotlin2/OngoingStubbing.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockitokotlin2/OngoingStubbing.kt
@@ -29,6 +29,7 @@ import org.mockito.Mockito
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.mockito.stubbing.OngoingStubbing
+import kotlin.DeprecationLevel.ERROR
 import kotlin.reflect.KClass
 
 
@@ -63,7 +64,19 @@ fun <T> OngoingStubbing<T>.doReturn(t: T, vararg ts: T): OngoingStubbing<T> {
 /**
  * Sets consecutive return values to be returned when the method is called.
  */
+@Deprecated(
+      "Use doReturnConsecutively instead",
+      ReplaceWith("doReturnConsecutively(ts)"),
+      level = ERROR
+)
 inline infix fun <reified T> OngoingStubbing<T>.doReturn(ts: List<T>): OngoingStubbing<T> {
+    return doReturnConsecutively(ts)
+}
+
+/**
+ * Sets consecutive return values to be returned when the method is called.
+ */
+inline infix fun <reified T> OngoingStubbing<T>.doReturnConsecutively(ts: List<T>): OngoingStubbing<T> {
     return thenReturn(
           ts[0],
           *ts.drop(1).toTypedArray()

--- a/tests/src/test/kotlin/test/Classes.kt
+++ b/tests/src/test/kotlin/test/Classes.kt
@@ -88,6 +88,7 @@ abstract class NonThrowingConstructorWithArgument {
         error("Error in constructor")
     }
 
+    @Suppress("UNUSED_PARAMETER")
     constructor(s: String)
 }
 

--- a/tests/src/test/kotlin/test/OngoingStubbingTest.kt
+++ b/tests/src/test/kotlin/test/OngoingStubbingTest.kt
@@ -255,7 +255,7 @@ class OngoingStubbingTest : TestBase() {
     fun doReturn_withSingleItemList() {
         /* Given */
         val mock = mock<Open> {
-            on { stringResult() } doReturn listOf("a", "b")
+            on { stringResult() } doReturnConsecutively listOf("a", "b")
         }
 
         /* Then */
@@ -330,7 +330,7 @@ class OngoingStubbingTest : TestBase() {
         /* When */
         try {
             mock.stringResult()
-        } catch(e: UnfinishedStubbingException) {
+        } catch (e: UnfinishedStubbingException) {
             /* Then */
             expect(e.message).toContain("Unfinished stubbing detected here:")
             expect(e.message).toContain("-> at test.OngoingStubbingTest.testMockitoStackOnUnfinishedStubbing")


### PR DESCRIPTION
This fixes an conflicting overloads issue in the following case:

```
mock<() -> List<String>> {
  on { invoke(any()) }.doReturn(emptyList())
}
```

Here `on` returns an `OngoingStubbing<List<String>>`, and calling
`doReturn(List<T>)` can't choose between the single element parameter
and the multi-item parameter.

This is a breaking change, but can be simply fixed by the tools in
IDEA.

See #274, will be fixed when `OngoingStubbing<T>.doReturn(List<T>)` is removed.