### PR TITLE
Bump mockito to version 2.21.0

### DIFF
--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compileOnly 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.23.3'
 
-    compile "org.mockito:mockito-core:2.19.0"
+    compile "org.mockito:mockito-core:2.21.0"
 
     testCompile 'junit:junit:4.12'
     testCompile 'com.nhaarman:expect.kt:1.0.0'


### PR DESCRIPTION
Bump mockito to version 2.21.0

Mockito 2.19.0 (with byte buddy 1.8.10) misses an important bug fix for Android lint.
For details see: https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.8.11