### PR TITLE
Update README.md: Configuration 'compile' is obsolete and has been replaced 'implementation'

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Mockito-Kotlin is available on Maven Central and JCenter.
 For Gradle users, add the following to your `build.gradle`, replacing `x.x.x` with the latest version:
 
 ```groovy
-testCompile "com.nhaarman.mockitokotlin2:mockito-kotlin:x.x.x"
+testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:x.x.x"
 ```
 
 ## Example


### PR DESCRIPTION
The testCompile configuration inherited from the Java plugin are still available but are deprecated. 
[The Java Library plugin configurations](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph)

It is a minor modification... 
Thank you.