### PR TITLE
Update to Kotlin 1.3, migrate to stable coroutines and update Mockito

### DIFF
--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compileOnly 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.30.0-eap13'
 
-    compile "org.mockito:mockito-core:2.21.0"
+    compile "org.mockito:mockito-core:2.23.0"
 
     testCompile 'junit:junit:4.12'
     testCompile 'com.nhaarman:expect.kt:1.0.0'

--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -3,7 +3,7 @@ apply from: '../publishing.gradle'
 apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
-    ext.kotlin_version = "1.3.0-rc-146 "
+    ext.kotlin_version = "1.3.0-rc-146"
 
     repositories {
         mavenCentral()

--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -3,7 +3,7 @@ apply from: '../publishing.gradle'
 apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
-    ext.kotlin_version = "1.3.0-rc-116"
+    ext.kotlin_version = "1.3.0-rc-146 "
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
This is fixes #294 and also solves #295. As Kotlin Coroutines have been moved out of the experimental package, weird errors can appear. With the new Mockito version `2.23.0`, Stable Coroutines are also supported (as well as experimental coroutines - using old Kotlin versions doesn't break it).
