### PR TITLE
Add argumentCaptor that create many at once for easy destructuring addresses #233

### DIFF
--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockitokotlin2/ArgumentCaptor.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockitokotlin2/ArgumentCaptor.kt
@@ -37,6 +37,54 @@ inline fun <reified T : Any> argumentCaptor(): KArgumentCaptor<T> {
 }
 
 /**
+ * Creates 2 [KArgumentCaptor]s for given types.
+ */
+inline fun <reified A: Any, reified B: Any> argumentCaptor2(): Pair<KArgumentCaptor<A>, KArgumentCaptor<B>> {
+    return Pair(KArgumentCaptor(ArgumentCaptor.forClass(A::class.java), A::class),
+            KArgumentCaptor(ArgumentCaptor.forClass(B::class.java), B::class))
+}
+
+/**
+ * Creates 3 [KArgumentCaptor]s for given types.
+ */
+inline fun <reified A: Any, reified B: Any, reified C: Any> argumentCaptor3(): Triple<KArgumentCaptor<A>, KArgumentCaptor<B>, KArgumentCaptor<C>> {
+    return Triple(
+            KArgumentCaptor(ArgumentCaptor.forClass(A::class.java), A::class),
+            KArgumentCaptor(ArgumentCaptor.forClass(B::class.java), B::class),
+            KArgumentCaptor(ArgumentCaptor.forClass(C::class.java), C::class))
+}
+
+data class ArgumentCaptorHolder4<out A, out B, out C, out D>(
+        val first: A, val second: B, val third: C, val fourth: D)
+data class ArgumentCaptorHolder5<out A, out B, out C, out D, out E>(
+        val first: A, val second: B, val third: C, val fourth: D, val fifth: E)
+
+
+/**
+ * Creates 4 [KArgumentCaptor]s for given types.
+ */
+inline fun <reified A: Any, reified B: Any, reified C: Any, reified D: Any> argumentCaptor4(): ArgumentCaptorHolder4<KArgumentCaptor<A>, KArgumentCaptor<B>, KArgumentCaptor<C>, KArgumentCaptor<D>> {
+    return ArgumentCaptorHolder4(
+            KArgumentCaptor(ArgumentCaptor.forClass(A::class.java), A::class),
+            KArgumentCaptor(ArgumentCaptor.forClass(B::class.java), B::class),
+            KArgumentCaptor(ArgumentCaptor.forClass(C::class.java), C::class),
+            KArgumentCaptor(ArgumentCaptor.forClass(D::class.java), D::class))
+}
+/**
+ * Creates 4 [KArgumentCaptor]s for given types.
+ */
+inline fun <reified A: Any, reified B: Any, reified C: Any, reified D: Any, reified E: Any> argumentCaptor5(): ArgumentCaptorHolder5<KArgumentCaptor<A>, KArgumentCaptor<B>, KArgumentCaptor<C>, KArgumentCaptor<D>, KArgumentCaptor<E>> {
+    return ArgumentCaptorHolder5(
+            KArgumentCaptor(ArgumentCaptor.forClass(A::class.java), A::class),
+            KArgumentCaptor(ArgumentCaptor.forClass(B::class.java), B::class),
+            KArgumentCaptor(ArgumentCaptor.forClass(C::class.java), C::class),
+            KArgumentCaptor(ArgumentCaptor.forClass(D::class.java), D::class),
+            KArgumentCaptor(ArgumentCaptor.forClass(E::class.java), E::class))
+}
+
+
+
+/**
  * Creates a [KArgumentCaptor] for given type, taking in a lambda to allow fast verification.
  */
 inline fun <reified T : Any> argumentCaptor(f: KArgumentCaptor<T>.() -> Unit): KArgumentCaptor<T> {

--- a/tests/src/test/kotlin/test/ArgumentCaptorTest.kt
+++ b/tests/src/test/kotlin/test/ArgumentCaptorTest.kt
@@ -23,6 +23,82 @@ class ArgumentCaptorTest : TestBase() {
     }
 
     @Test
+    fun argumentCaptor_destructuring2() {
+        /* Given */
+        val date: Date = mock()
+
+        /* When */
+        date.time = 5L
+
+        /* Then */
+        val (captor1, captor2) = argumentCaptor2<Long, Long>()
+        verify(date).time = captor1.capture()
+        verify(date).time = captor2.capture()
+        expect(captor1.lastValue).toBe(5L)
+        expect(captor2.lastValue).toBe(5L)
+    }
+
+    @Test
+    fun argumentCaptor_destructuring3() {
+        /* Given */
+        val date: Date = mock()
+
+        /* When */
+        date.time = 5L
+
+        /* Then */
+        val (captor1, captor2, captor3) = argumentCaptor3<Long, Long, Long>()
+        val verifyCaptor:KArgumentCaptor<Long>.() ->Unit = {
+            verify(date).time = capture()
+            expect(lastValue).toBe(5L)
+        }
+        captor1.apply(verifyCaptor)
+        captor2.apply(verifyCaptor)
+        captor3.apply(verifyCaptor)
+    }
+
+    @Test
+    fun argumentCaptor_destructuring4() {
+        /* Given */
+        val date: Date = mock()
+
+        /* When */
+        date.time = 5L
+
+        /* Then */
+        val (captor1, captor2, captor3, captor4) = argumentCaptor4<Long, Long, Long, Long>()
+        val verifyCaptor:KArgumentCaptor<Long>.() ->Unit = {
+            verify(date).time = capture()
+            expect(lastValue).toBe(5L)
+        }
+        captor1.apply(verifyCaptor)
+        captor2.apply(verifyCaptor)
+        captor3.apply(verifyCaptor)
+        captor4.apply(verifyCaptor)
+    }
+
+    @Test
+    fun argumentCaptor_destructuring5() {
+        /* Given */
+        val date: Date = mock()
+
+        /* When */
+        date.time = 5L
+
+        /* Then */
+        val (captor1, captor2, captor3, captor4, captor5) = argumentCaptor5<Long, Long, Long, Long, Long>()
+        val verifyCaptor:KArgumentCaptor<Long>.() ->Unit = {
+            verify(date).time = capture()
+            expect(lastValue).toBe(5L)
+        }
+        captor1.apply(verifyCaptor)
+        captor2.apply(verifyCaptor)
+        captor3.apply(verifyCaptor)
+        captor4.apply(verifyCaptor)
+        captor5.apply(verifyCaptor)
+    }
+
+    @Test
     fun argumentCaptor_withNullValue_usingNonNullable() {
         /* Given */
         val m: Methods = mock()


### PR DESCRIPTION
This addresses #233 and provides an helper to create up to 5 `argumentCaptors` at once