### PR TITLE
Add reified support for refEq like other matchers

### DIFF
--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockitokotlin2/Matchers.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockitokotlin2/Matchers.kt
@@ -133,7 +133,7 @@ fun <T : Any> notNull(): T? {
  * Object argument that is reflection-equal to the given value with support for excluding
  * selected fields from a class.
  */
-fun <T> refEq(value: T, vararg excludeFields: String): T? {
-    return Mockito.refEq(value, *excludeFields)
+inline fun <reified T : Any> refEq(value: T, vararg excludeFields: String): T {
+    return Mockito.refEq<T>(value, *excludeFields) ?: createInstance()
 }
 


### PR DESCRIPTION
This takes care of #328 

Follow the same pattern as with other matchers using `reified` generics to generate an instance to avoid having a warning or failure when using `!!`
