### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,21 +4,21 @@ language: java
 
 matrix:
   include:
-  - jdk: oraclejdk8
+  - jdk: openjdk8
     env: TERM=dumb MOCK_MAKER=mock-maker-inline KOTLIN_VERSION=1.0.7
-  - jdk: oraclejdk8
+  - jdk: openjdk8
     env: TERM=dumb MOCK_MAKER=mock-maker-inline KOTLIN_VERSION=1.1.61
-  - jdk: oraclejdk8
+  - jdk: openjdk8
     env: TERM=dumb MOCK_MAKER=mock-maker-inline KOTLIN_VERSION=1.2.50
-  - jdk: oraclejdk8
+  - jdk: openjdk8
     env: TERM=dumb MOCK_MAKER=mock-maker-inline KOTLIN_VERSION=1.3.40
-  - jdk: oraclejdk8
+  - jdk: openjdk8
     env: TERM=dumb KOTLIN_VERSION=1.0.7
-  - jdk: oraclejdk8
+  - jdk: openjdk8
     env: TERM=dumb KOTLIN_VERSION=1.1.61
-  - jdk: oraclejdk8
+  - jdk: openjdk8
     env: TERM=dumb KOTLIN_VERSION=1.2.50
-  - jdk: oraclejdk8
+  - jdk: openjdk8
     env: TERM=dumb KOTLIN_VERSION=1.3.40
 
 


### PR DESCRIPTION
CI is failing because the new images of travis doesn't work with `oraclejdk8`. For this reason I moved to `openjdk8`